### PR TITLE
Refactor accordion

### DIFF
--- a/source/_accordion.html.erb
+++ b/source/_accordion.html.erb
@@ -1,6 +1,6 @@
-<ul class="accordion-menus"> 
-  <li class="expanded">
-    <a href="#" class="js-nolink">Item 1</a>
+<ul class="accordion-menus">
+  <li>
+    <a href="#" class="js-accordion-trigger">Item 1</a>
     <ul class="submenu">
       <li>
         <a href="">Sub Item 1</a>
@@ -10,8 +10,8 @@
       </li>
     </ul>
   </li>
-  <li class="expanded">
-    <a href="#" class="js-nolink">Item 2</a>
+  <li>
+    <a href="#" class="js-accordion-trigger">Item 2</a>
     <ul class="submenu">
       <li>
         <a href="">Sub Item 1</a>
@@ -24,10 +24,10 @@
 </ul>
 
 <script>
-  jQuery('.expanded').find('.js-nolink') // find the .js-nolink inside .expanded
+  jQuery('.js-accordion-trigger') // find the trigger
     .bind('click focus', function(){
       jQuery(this).parent().find('ul').slideToggle('fast');  // apply the toggle to the ul
-      jQuery(this).parent().toggleClass('expand'); 
-      event.preventDefault()
+      jQuery(this).parent().toggleClass('is-expanded');
+      event.preventDefault();
   });
 </script>

--- a/source/stylesheets/refills/_accordion.scss
+++ b/source/stylesheets/refills/_accordion.scss
@@ -12,12 +12,10 @@
 
   li {
     border-bottom: $accordion-menu-border;
-    padding-bottom: $accordion-menu-list-padding;
-    padding-top: $accordion-menu-list-padding;
 
-    a {
-      margin-bottom: $accordion-menu-list-padding;
-      padding-left: $accordion-menu-list-padding;
+    > a {
+      padding: $accordion-menu-list-padding;
+      display: block;
     }
 
     &:last-child {
@@ -31,7 +29,6 @@
 
   ul.submenu {
     display: none;
-    margin-top: $accordion-menu-list-padding;
 
     li {
       background-color: $accordion-menu-sub-background;
@@ -47,7 +44,7 @@
     }
   }
 
-  .expand {
+  .is-expanded {
     display: block;
     padding-bottom: 0;
   }


### PR DESCRIPTION
Whole li is clickable (block-level anchor).

Change .expanded to .is-expanded.

Decouple html and js.
