### PR TITLE
Adjust line-height on pre elements

### DIFF
--- a/source/stylesheets/_refills-styles.scss
+++ b/source/stylesheets/_refills-styles.scss
@@ -326,6 +326,7 @@ pre[class*="language-"] {
   height: 300px;
   border-top: 2px solid silver;
   background: #F8F8F8;
+  line-height: 1em;
 
   @include media($medium-screen) {
     // box-shadow: -2px 0 0 rgba(0,0,0,0.1);


### PR DESCRIPTION
I just added the `line-height: 1em;` to the pre style in the `_refills-styles.css` file. This works great in my browser, I have no idea why it didn't work before on yours @Magnus-G. Could you try this out and see how it looks?
