### PR TITLE
Center copy in dynamic height image gradients

### DIFF
--- a/source/stylesheets/refills/_image-gradient-dynamic.scss
+++ b/source/stylesheets/refills/_image-gradient-dynamic.scss
@@ -26,17 +26,17 @@
 
   .copy {
     position: absolute;
+    top: 50%;
     left: 50%;
     margin: auto;
     z-index: 999;
-    top: 40%;
     text-align: center;
+    @include transform(translate(-50%, -50%));
 
     p {
       line-height: 1.5em;
       padding: 1em 2em;
       position: relative;
-      left: -50%;
       color: white;
       font-weight: 800;
       background-color: transparentize(black, .6);


### PR DESCRIPTION
This is using css3 transforms to avoid inconsistent css and unsemantic markup. This is not supported in IE8.
