### PR TITLE
Left align breadcrumbs and add spacing

### DIFF
--- a/source/_breadcrumbs.html.erb
+++ b/source/_breadcrumbs.html.erb
@@ -4,5 +4,4 @@
   <a href="#">Three</a>
   <a href="#">Four</a>
   <a href="#">Five</a>
-  <a href="#">Six</a>
 </div>

--- a/source/stylesheets/refills/_breadcrumbs.scss
+++ b/source/stylesheets/refills/_breadcrumbs.scss
@@ -10,11 +10,7 @@
   $breadcrumb-color-active: $breadcrumb-color;
 
   @include inline-block;
-  border-radius: $base-border-radius;
-  margin: 0;
-  padding: 0;
-  border-radius: $base-border-radius;
-  display: block;
+  text-align: left;
   margin-bottom: $base-line-height;
 
   a {
@@ -28,6 +24,7 @@
     padding: 0 $breadcrumb-height/4 0 $breadcrumb-height/2;
     position: relative;
     text-decoration: none;
+    margin-bottom: 2px;
 
     &:first-child {
       padding-left: $breadcrumb-height/2;


### PR DESCRIPTION
This aligns the breadcrumbs to the left but allows the breadcrumbs as a component to be centered. It also adds a bit of vertical spacing between the lines of breadcrumbs when they wrap.

![screen shot 2014-03-26 at 10 31 59](https://f.cloud.github.com/assets/66666/2522964/2d4e90c6-b4ca-11e3-921e-b00f5eceac6d.png)
![4e6307f4-adf4-4ba9-993b-bbbb257e4ca6](https://f.cloud.github.com/assets/66666/2522980/6b59be54-b4ca-11e3-9940-11dbbe6f6e63.png)

@Magnus-G I discussed the collapsing of breadcrumbs a bit with Reda and we agreed on that it might take a lot of javascript and also collapsing almost all breadcrumbs kind of makes them unusable since you can only click the first and last one. What do you think?
