### PR TITLE
require 'rails/generators' in import_generator.rb

### DIFF
--- a/lib/refills/import_generator.rb
+++ b/lib/refills/import_generator.rb
@@ -1,3 +1,5 @@
+require 'rails/generators'
+
 module Refills
   class ImportGenerator < Rails::Generators::Base
     desc 'Copy refills'


### PR DESCRIPTION
On Rails 4.1 (and I think earlier versions too) the import generator causes an exception when loaded because the `rails/generators` are not required.

> /.../refills-0.0.1/lib/refills/import_generator.rb:2:in `module:Refills': uninitialized constant Rails::Generators (NameError)

This [StackOverflow answer](http://stackoverflow.com/a/14884631/1028953) pointed me in the right direction.
