### PR TITLE
Remove secure on thoughtbot url

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
         <div class="refills-header">
   <h1>Refills</h1>
   <h2><span>Refills</span> are prepackaged patterns and components, built on top of <a href="http://www.bourbon.io">Bourbon</a>, <a href="http://bitters.bourbon.io/">Bitters</a>, and <a href="http://neat.bourbon.io/">Neat</a>.</h2>
-  <p>Managed by <a href="https://thoughtbot.com/">thoughtbot</a>, instructions at <a href="https://github.com/thoughtbot/refills">Github</a></p>
+  <p>Managed by <a href="http://thoughtbot.com/">thoughtbot</a>, instructions at <a href="https://github.com/thoughtbot/refills">Github</a></p>
 </div>
 
 <div id="example1" class="refills-wrapper">


### PR DESCRIPTION
Hi I know it's a small change but when I click on thoughtbots link it ships me to https instead of http and chrome was freaking out so I changed it.

Thanks!
