### PR TITLE
Change '.menu-anchor' to a button.

### DIFF
--- a/source/_sliding-menu.html.erb
+++ b/source/_sliding-menu.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <a class="js-menu-trigger menu-anchor">&#9776;</a>
+  <button type="button" class="js-menu-trigger menu-anchor">&#9776;</button>
 </div>
 
 <nav class="js-menu sliding-menu-content">


### PR DESCRIPTION
What do you think about changing the `.menu-anchor` from an anchor to a button?  Since it doesn't link to anywhere and doesn't function without JavaScript, it seems like it's better suited to be a `button` element. No JavaScript will need to be updated and as an added benefit the `button` element will be selected when tabbing.  Might want to update the class name if it's no longer an anchor.
