### PR TITLE
require 'rails/generators' in list_generator.rb'

### DIFF
--- a/lib/refills/list_generator.rb
+++ b/lib/refills/list_generator.rb
@@ -1,3 +1,5 @@
+require 'rails/generators'
+
 module Refills
   class ListGenerator < Rails::Generators::Base
     desc 'List refills'


### PR DESCRIPTION
See closed pull request #33. I was getting the same "uninitialized constant Rails::Generators (NameError)" when trying the list generator, so I added the same require to list_generator.rb. That seems to have solved it.
