### PR TITLE
Change closing h2 tag to p tag on comment detail

### DIFF
--- a/source/_comment.html.erb
+++ b/source/_comment.html.erb
@@ -5,7 +5,7 @@
   <div class="comment-content">
     <h1>First Comment Title or Author</h1>
     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Optio, aspernatur, quia modi minima debitis tempora ducimus quam vero impedit alias earum nemo error tenetur sed.</p>
-    <p class="comment-detail">Date or details about this post</h2>
+    <p class="comment-detail">Date or details about this post</p>
   </div>
 </div>
 
@@ -16,6 +16,6 @@
   <div class="comment-content">
     <h1>Another One</h1>
     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Optio, aspernatur, quia modi minima debitis tempora ducimus quam vero impedit alias earum nemo error tenetur sed.</p>
-    <p class="comment-detail">Date or details about this post</h2>
+    <p class="comment-detail">Date or details about this post</p>
   </div>
 </div>


### PR DESCRIPTION
This commit changes the closing h2 tag to a closing p tag on the comment
detail section of the comment source.
