### PR TITLE
Button group styling

### DIFF
--- a/source/stylesheets/refills/_button-group.scss
+++ b/source/stylesheets/refills/_button-group.scss
@@ -21,7 +21,7 @@
     }
 
     &:first-child {
-      @include border-bottom-radius(0);
+      @include border-right-radius(0);
       border-top-width: 1px;
     }
 
@@ -30,7 +30,7 @@
     }
 
     &:last-child {
-      @include border-top-radius(0);
+      @include border-left-radius(0);
     }
 
     @include media($medium-screen) {


### PR DESCRIPTION
The site's documentation/example depicts a horizontal button group, but the code appears to be written for a vertical one. Is this intentional?
