### PR TITLE
Stopped search button being aligned to the left

### DIFF
--- a/source/stylesheets/refills/_navigation.scss
+++ b/source/stylesheets/refills/_navigation.scss
@@ -234,7 +234,7 @@ header.navigation {
 
       button[type=submit] {
         @include button(simple, lighten($navigation-search-background, 10));
-        @include position(absolute, 0.3em 0.3em 0.3em 0);
+        @include position(absolute, 0.3em 0.3em 0.3em null);
         outline: none;
         padding: 5px 15px;
 


### PR DESCRIPTION
Using refills 0.0.2, when I generate the refills nav bar, by default the search button is aligned to the left of the enclosing input field.

![screen shot 2014-05-12 at 11 08 39 pm](https://cloud.githubusercontent.com/assets/111963/2951057/1d3d5b86-da22-11e3-8ca0-dc48b5f8c5a0.png)

This hides some of the placeholder text, and is different to how it appears on the refills home page. I believe that the left position should not be set, which naturally aligns the button to the right (with the other positioning values effectively acting as margins) and this is how it's defined on the refills home page.

![screen shot 2014-05-12 at 11 08 53 pm](https://cloud.githubusercontent.com/assets/111963/2951073/58e2c022-da22-11e3-8861-6e5439b515bf.png)

To achieve this I've set the left position to null, so it is not set at all. This makes it align to the right as I would expect.
