### PR TITLE
Expand navigation link to fill height of header

### DIFF
--- a/source/stylesheets/refills/_navigation.scss
+++ b/source/stylesheets/refills/_navigation.scss
@@ -99,7 +99,6 @@ header.navigation {
       background: transparent;
       display: inline;
       line-height: $navigation-height;
-      padding-right: 2em;
       text-decoration: none;
       width: auto;
     }
@@ -107,6 +106,8 @@ header.navigation {
     a {
       font-weight: 400;
       color: $navigation-color;
+      display: inline-block;
+      padding-right: 1em;
 
       &:hover {
         color: $navigation-color-hover;


### PR DESCRIPTION
The link on the navigation header bar currently only covers the text of the link. I've expanded the link to cover the entire height of the navigation header and added some horizontal padding so that it's easier to find and click on it. :smiley: 
