### PR TITLE
Removed redundant information from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,19 +22,7 @@ See examples and get the code snippets [here](http://thoughtbot.github.io/refill
 
 [Install Bitters](http://bitters.bourbon.io/)
 
-
-Make sure the following lines in "_bitters.scss" are uncommented:
-
-```scss
-@import "neat-helpers"; // or "neat/neat-helpers" when not in Rails
-@import "grid-settings";
-```
-
-
 [Install jQuery](http://www.w3schools.com/jquery/jquery_install.asp) (if you are using any of the components/patterns that require Javascript. Javascript, when used, can be found at the bottom of the HTML file.)
-
-Click "Show Code" under the component/pattern you want in [Refills](http://thoughtbot.github.io/refills/) and paste it into your project. 
-If a component/pattern has javascript it is placed in the HTML.erb file. Feel free to place it somewhere else in your project.
 
 # Using Refills
 


### PR DESCRIPTION
I found the read me a little confusing, so I've removed some parts that I thought were misleading or confusing:
1. Removed mention of neat-helpers and grid-settings (these are optional in neat, depending on how you use it - better to let the neat readme explain that?)
2. Removed duplicate explanation of how to use refillls (copy/paste code explanation was under both installing dependencies and using refills sections)
