### PR TITLE
Fix generators for js

### DIFF
--- a/lib/refills/import_generator.rb
+++ b/lib/refills/import_generator.rb
@@ -15,7 +15,9 @@ module Refills
     end
 
     def copy_javascripts
-      copy_file javascript_template, javascript_destination
+      if File.exist? File.join(ImportGenerator.source_root, javascript_template)
+        copy_file javascript_template, javascript_destination
+      end
     end
 
     private


### PR DESCRIPTION
On master it seems like the generators are broken whenever a refill does not have a javascript file. For example, if I run:

```
$ rails generate refills:import footer-2
  create  app/views/refills/_footer_2.html.erb
  create  app/assets/stylesheets/refills/_footer_2.scss
Could not find "javascripts/refills/_footer-2.js" in any of your source paths. Your current source paths are: 
```

/Users/iain/Programs/OSS/refills/source

I believe this has been broken since #62 separated out the javascript from templates.

My fix for this is to check whether the javascript file exists before trying to copy it. However, I've also used this as a chance to refactor the code for generating javascript to match the conventions used by #45 (which makes up the bulk of the changes you can see in the diff)
