### PR TITLE
Added child selector to li.tab-header-and-conent section 

### DIFF
--- a/source/stylesheets/refills/_accordion-tabs-minimal.scss
+++ b/source/stylesheets/refills/_accordion-tabs-minimal.scss
@@ -75,7 +75,7 @@
     }
   }
 
-  li.tab-header-and-content section {
+  li.tab-header-and-content > section {
     padding: $base-line-height $gutter;
     background: $tab-content-background;
     display: none;

--- a/source/stylesheets/refills/_accordion-tabs.scss
+++ b/source/stylesheets/refills/_accordion-tabs.scss
@@ -75,7 +75,7 @@
     }
   }
 
-  li.tab-header-and-content section {
+  li.tab-header-and-content > section {
     padding: $base-line-height $gutter;
     background: $tab-content-background;
     display: none;


### PR DESCRIPTION
The current `li.tab-header-and-content  section` was causing all `<section>` elements to be hidden even when the tab was activated. Only the first child `section` should be affected here.
