### PR TITLE
Incorrect javascript directory name

### DIFF
--- a/lib/refills/import_generator.rb
+++ b/lib/refills/import_generator.rb
@@ -23,7 +23,7 @@ module Refills
     def copy_javascripts
       copy_file_if_exists(
         File.join('javascripts', 'refills', javascript_name),
-        File.join('app', 'assets', 'javascript', 'refills', javascript_name),
+        File.join('app', 'assets', 'javascripts', 'refills', javascript_name),
       )
     end
 


### PR DESCRIPTION
Rails uses the pluralized "javascripts" for JS assets.