### PR TITLE
Firefox compatibility

### DIFF
--- a/source/javascripts/refills/accordion.js
+++ b/source/javascripts/refills/accordion.js
@@ -1,5 +1,5 @@
-$('.js-accordion-trigger').bind('click', function(){
+$('.js-accordion-trigger').bind('click', function(e){
   jQuery(this).parent().find('.submenu').slideToggle('fast');  // apply the toggle to the ul
   jQuery(this).parent().toggleClass('is-expanded');
-  event.preventDefault();
+  e.preventDefault();
 });


### PR DESCRIPTION
With this, Firefox stops complaining about "event" not being defined, in the console.
