### PR TITLE
Allow dropdown to act as a normal dropdown

### DIFF
--- a/source/javascripts/refills/dropdown.js
+++ b/source/javascripts/refills/dropdown.js
@@ -1,13 +1,13 @@
 $(document).ready(function(){
-  $('.dropdown-button').click(function(){
-    $('.menu').toggleClass('show-menu');
-    $('.menu > li').click(function(){
-      $('.menu').removeClass('show-menu');
+  $(".dropdown-button").click(function(){
+    $(".menu").toggleClass("show-menu");
+    $(".menu > li").click(function(){
+      $(".menu").removeClass("show-menu");
     });
     // simulate a select tag by showing selected value
     // instead of placeholder when a value is selected.
-    $('.menu.select > li').click(function(){
-      $('.dropdown-button').html($(this).html());
+    $(".menu.select > li").click(function(){
+      $(".dropdown-button").html($(this).html());
     });
   });
 });


### PR DESCRIPTION
Adding the .select class to .menu makes the dropdown act like a select.
Otherwise, it acts like a simple dropdown, keeping the "dropdown-button" value when clicking on a component of the dropdown.
It can be useful if you need a simple dropdown, but still use the version where it acts like a select.
