### PR TITLE
Remove the unneeded "push" div for sticky footer

### DIFF
--- a/source/_footer_2.html.erb
+++ b/source/_footer_2.html.erb
@@ -1,6 +1,5 @@
 <!--<div class="wrapper-for-content-outside-of-footer">
    Uncomment this whole section for a sticky footer. The content of the page should be inside of this .wrapper-for-content-outside-of-footer
-  <div class="push"></div>
 </div>-->
 
 <footer class="footer-2">

--- a/source/stylesheets/refills/_footer-2.scss
+++ b/source/stylesheets/refills/_footer-2.scss
@@ -11,7 +11,12 @@
 //  height: 100%;
 // }
 
-// .footer-2, .push {
+// .wrapper-for-content-outside-of-footer:after {
+//   content: "";
+//   display: block;
+// }
+
+// .footer-2, .wrapper-for-content-outside-of-footer:after {
 //   height: 17em;
 
 //   @include media($large-screen) {


### PR DESCRIPTION
Rather than use an extra div, use the :after pseudo-element on the
.wrapper-for-content-outside-of-footer div.
