### PR TITLE
Add `spec` coverage for `Refills::ImportGenerator`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 build
 Gemfile.lock
 pkg
+tmp/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+rvm:
+- 2.0.0
+- 1.9.3
+- jruby-19mode
+- rbx-2
+script: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,14 @@ gem 'middleman', '~>3.3.3'
 gem 'bitters'
 gem 'bourbon', '~>3.2.0'
 gem 'middleman-livereload', '~> 3.1.0'
+gem 'middleman-gh-pages'
 gem 'neat', '~> 1.5.0'
 
 # For faster file watcher updates on Windows:
 gem 'wdm', '~> 0.1.0', :platforms => [:mswin, :mingw]
+
+group :test do
+  gem 'rspec'
+  gem 'generator_spec'
+  gem 'railties'
+end

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Refills
 
+[![Build Status](https://travis-ci.org/thoughtbot/refills.svg?branch=master)](https://travis-ci.org/thoughtbot/refills)
+
 ## Prepackaged patterns and components, built on top of Bourbon, Bitters and Neat
 
 [Bourbon](http://bourbon.io) provides Sass mixins and eliminates vendor prefixes, for faster CSS coding.
@@ -43,9 +45,10 @@ The gem provides the following Rails generators
 * `rails generate refills:list`
 Lists all the available snippets
 
-* `rails generate refills:import SNIPPET`
-Copies partials to `app/views/refills` and stylesheets to
-`app/assets/stylesheets/refills`
+* `rails generate refills:import SNIPPET` copies:
+  * partials to `app/views/refills`
+  * stylesheets to `app/assets/stylesheets/refills`
+  * javascripts to `app/assets/javascripts/refills`
 
 # Submitting components or patterns
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,8 @@
 require 'bundler/gem_tasks'
 require 'middleman-gh-pages'
+
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec
+task publish: :spec

--- a/lib/refills/import_generator.rb
+++ b/lib/refills/import_generator.rb
@@ -23,7 +23,7 @@ module Refills
     def copy_javascripts
       copy_file_if_exists(
         File.join('javascripts', 'refills', javascript_name),
-        File.join('app', 'assets', 'javascript', 'refills', javascript_name),
+        File.join('app', 'assets', 'javascripts', 'refills', javascript_name),
       )
     end
 

--- a/spec/refills/import_generator_spec.rb
+++ b/spec/refills/import_generator_spec.rb
@@ -1,0 +1,89 @@
+require "spec_helper"
+
+describe Refills::ImportGenerator, type: :generator do
+  SNIPPETS = {
+    accordion: %w[scss js erb],
+    accordion_tabs: %w[scss js erb],
+    badges: %w[scss erb],
+    breadcrumbs: %w[scss erb],
+    browser: %w[scss erb],
+    button_group: %w[scss erb],
+    cards: %w[scss erb],
+    centered_navigation: %w[scss js erb],
+    code: %w[erb],
+    comment: %w[scss erb],
+    device: %w[scss erb],
+    dropdown: %w[scss js erb],
+    footer: %w[scss erb],
+    grid_items: %w[scss erb],
+    grid_items_lines: %w[scss erb],
+    hero: %w[scss erb],
+    hover_tile_animation: %w[scss erb],
+    icon_bullet_points: %w[scss erb],
+    image_gradient_dynamic: %w[scss erb],
+    intro_text: %w[scss erb],
+    modal: %w[scss erb],
+    navigation: %w[scss js erb],
+    pagination: %w[scss erb],
+    progress_bar: %w[scss erb],
+    progress_bar_indication: %w[scss erb],
+    search_bar: %w[scss erb],
+    search_tools: %w[scss js erb],
+    side_image: %w[scss erb],
+    sliding_menu: %w[scss js erb],
+    snippet: %w[erb],
+    switch: %w[scss erb],
+    tables: %w[scss erb],
+    tables_minimal: %w[scss erb],
+    "texture-legend" => %w[scss],
+    textures: %w[scss erb],
+    tooltip: %w[scss erb],
+    type_system_geometric: %w[scss erb],
+    type_system_rounded: %w[scss erb],
+    type_system_sans: %w[scss erb],
+    type_system_serif: %w[scss erb],
+    type_system_slab: %w[scss erb],
+    type_system_traditional: %w[scss erb],
+    vertical_tabs: %w[scss js erb],
+    video: %w[scss erb],
+  }
+
+  destination File.expand_path("../../tmp", File.dirname(__FILE__))
+
+  before do
+    ensure_previous_snippets_removed
+  end
+
+  SNIPPETS.each do |snippet, templates|
+    snippet   = snippet.to_s
+
+    if templates.include?("scss")
+      it "imports SCSS file for #{snippet.humanize}" do
+        run_generator [ snippet ]
+
+        assert_file "app/assets/stylesheets/refills/_#{snippet.dasherize}.scss"
+      end
+    end
+
+    if templates.include?("erb")
+      it "imports ERB template for #{snippet.humanize}" do
+        run_generator [ snippet ]
+
+        assert_file "app/views/refills/_#{snippet.underscore}.html.erb"
+      end
+    end
+
+    if templates.include?("js")
+      it "imports JS file for #{snippet.humanize}" do
+        run_generator [ snippet ]
+
+        assert_file "app/assets/javascripts/refills/#{snippet.underscore}.js"
+      end
+    end
+
+  end
+
+  def ensure_previous_snippets_removed
+    prepare_destination
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require "generator_spec"
+require "refills"


### PR DESCRIPTION
Adds test coverage for generating previously defined snippets. Provides a hook
to test future snippet generation.
