### PR TITLE
Fixes website issues caused by parallax component.

### DIFF
--- a/source/javascripts/refills/parallax.js
+++ b/source/javascripts/refills/parallax.js
@@ -1,9 +1,13 @@
 $(document).ready(function() {
-  parallax();
+  if ($("#js-parallax-window").length) {
+    parallax();
+  }
 });
 
 $(window).scroll(function(e) {
-  parallax();
+  if ($("#js-parallax-window").length) {
+    parallax();
+  }
 });
 
 function parallax(){


### PR DESCRIPTION
First this fixes #161 by checking for the existence of an element with the id `js-parallax-window` before allowing parallax() to be called, preventing `Uncaught TypeError: Cannot read property 'top' of undefined` errors on the website.

It also has the added benefit of fixing the slide out menus on the patterns and type systems pages of the website, which is what I really wanted working.
