### PR TITLE
base-line-height already in em units

### DIFF
--- a/source/stylesheets/base/_variables.scss
+++ b/source/stylesheets/base/_variables.scss
@@ -19,7 +19,7 @@ $header-line-height: 1.25;
 
 // Other Sizes
 $base-border-radius: 3px;
-$base-spacing: $base-line-height * 1em;
+$base-spacing: $base-line-height * 1;
 $base-z-index: 0;
 
 // Colors


### PR DESCRIPTION
Removes an `em`.

In [_variables.scss#L22](https://github.com/thoughtbot/refills/blob/891371da869ee0d041d356bf2f5d0ca00a36c534/source/stylesheets/base/_variables.scss#L22) this changes `$base-spacing: $base-line-height * 1em;` to `$base-spacing: $base-line-height * 1;`.

The reason for this is because `$base-line-height` is already in `em` units. It becomes `1.5em*em` and will error with `Error: 1.5em*em isn't a valid CSS value.`.

You can test this with the [Comments Refill](https://github.com/thoughtbot/refills/blob/891371da869ee0d041d356bf2f5d0ca00a36c534/source/stylesheets/refills/_comment.scss) which uses `margin-bottom: $base-spacing;` that is on the [Refills page](http://refills.bourbon.io/).

Thanks for the great code.
