### PR TITLE
fix for collapsing tabs when there is not enough content

### DIFF
--- a/source/_accordion_tabs.html.erb
+++ b/source/_accordion_tabs.html.erb
@@ -14,13 +14,13 @@
   <li class="tab-header-and-content">
     <a href="javascript:void(0)" class="tab-link">Third</a>
     <div class="tab-content">
-      <p>Donec mattis mauris gravida metus laoreet non rutrum sem viverra. Aenean nibh libero, viverra vel vestibulum in, porttitor ut sapien. Phasellus tempor lorem id justo ornare tincidunt. Nulla faucibus, purus eu placerat fermentum, velit mi iaculis nunc, bibendum tincidunt ipsum justo eu mauris. Nulla facilisi. Vestibulum vel lectus ac purus tempus suscipit nec sit amet eros. Nullam fringilla, enim eu lobortis dapibus, quam magna tincidunt nibh, sit amet imperdiet dolor justo congue turpis.</p>    
+      <p>Donec mattis mauris gravida metus laoreet non rutrum sem viverra. Aenean nibh libero, viverra vel vestibulum in, porttitor ut sapien. Phasellus tempor lorem id justo ornare tincidunt. Nulla faucibus, purus eu placerat fermentum, velit mi iaculis nunc, bibendum tincidunt ipsum justo eu mauris. Nulla facilisi. Vestibulum vel lectus ac purus tempus suscipit nec sit amet eros. Nullam fringilla, enim eu lobortis dapibus, quam magna tincidunt nibh, sit amet imperdiet dolor justo congue turpis.</p>
     </div>
   </li>
   <li class="tab-header-and-content">
     <a href="javascript:void(0)" class="tab-link">Last Item</a>
     <div class="tab-content">
-      <p>Sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Phasellus dui urna, mollis vel suscipit in, pharetra at ligula. Pellentesque a est vel est fermentum pellentesque sed sit amet dolor. Nunc in dapibus nibh. Aliquam erat volutpat. Phasellus vel dui sed nibh iaculis convallis id sit amet urna. Proin nec tellus quis justo consequat accumsan. Vivamus turpis enim, auctor eget placerat eget, aliquam ut sapien.</p>
+      <p>Sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
     </div>
   </li>
 </ul>

--- a/source/stylesheets/refills/_accordion-tabs.scss
+++ b/source/stylesheets/refills/_accordion-tabs.scss
@@ -75,6 +75,7 @@
   .tab-content {
     background: $tab-content-background;
     display: none;
+    width: 100%;
     padding: $base-spacing $gutter;
 
     @include media($tab-mode) {


### PR DESCRIPTION
Fixes the following. Check the last tab after build.

![](http://cl.ly/Z3t1/Image%202014-12-22%20at%202.07.36%20pm.png)