### PR TITLE
Badges & Flashes

### DIFF
--- a/source/_badges.html.erb
+++ b/source/_badges.html.erb
@@ -1,7 +1,7 @@
-<div class="badges">
-	<span class="badge">4</span>
-	<span class="badge dark">4</span>
-	<span class="badge error">4</span>
-	<span class="badge notice">4</span>
-	<span class="badge success">4</span>
+<div>
+  <span class="badge">4</span>
+  <span class="badge-alert">4</span>
+  <span class="badge-error">4</span>
+  <span class="badge-notice">4</span>
+  <span class="badge-success">4</span>
 </div>

--- a/source/stylesheets/refills/_badges.scss
+++ b/source/stylesheets/refills/_badges.scss
@@ -1,53 +1,37 @@
-.badges {  
-  ///////////////////////////////////////////////////////////////////////////////////
-  $base-border-color: gainsboro !default;
-  $base-font-size: 1em !default;
-  $base-line-height: 1.5em !default;
-  $base-accent-color: #477DCA !default;
-  $dark-gray: #333 !default;
-  $medium-gray: #999 !default;
-  //////////////////////////////////////////////////////////////////////////////////
+$badge-font-size: 0.75em !default;
+$medium-gray: #999 !default;
+$alert-color: #fff6bf !default;
+$error-color: #fbe3e4 !default;
+$notice-color: #e5edf8 !default;
+$success-color: #e6efc2 !default;
 
-  $badge-background: $medium-gray;
-  $badge-dark-color: $dark-gray;
-  $badge-error-color: #FBE3E4;
-  $badge-notice-color: lighten($base-accent-color, 40%);
-  $badge-success-color: #E6EFC2;
-  $badge-font-color: #fff;
-  $badge-font-size: $base-font-size * 0.75;
-
-  display: block;
-  margin-bottom: $base-line-height;
-
-  .badge {
-    background: $badge-background;
-    border-radius: 2em;
-    color: $badge-font-color;
-    display: inline-block;
-    font-size: $badge-font-size;
-    font-weight: 600;
-    line-height: 1em;
-    padding: 0.25em 1em;
-    text-align: center;
-
-    &.dark {
-      background: $badge-dark-color;
-    }
-
-    &.error {
-      background: $badge-error-color;
-      color: darken($badge-error-color, 60%);
-    }
-
-    &.notice {
-      background: $badge-notice-color;
-      color: darken($badge-notice-color, 60%);
-    }
-
-    &.success {
-      background: $badge-success-color;
-      color: darken($badge-success-color, 60%);
-    }
-  }
+@mixin badge($color: $medium-gray) {
+  background-color: $color;
+  border-radius: $badge-font-size * 5;
+  color: darken($color, 60%);
+  display: inline-block;
+  font-size: $badge-font-size;
+  font-weight: 600;
+  line-height: 1;
+  padding: 0.4em 1.2em;
 }
 
+.badge {
+  @include badge;
+}
+
+.badge-alert {
+  @include badge($alert-color);
+}
+
+.badge-error {
+  @include badge($error-color);
+}
+
+.badge-notice {
+  @include badge($notice-color);
+}
+
+.badge-success {
+  @include badge($success-color);
+}

--- a/source/stylesheets/refills/_flashes.scss
+++ b/source/stylesheets/refills/_flashes.scss
@@ -1,24 +1,20 @@
-//////////////////////////////////////////////////////////////////////////////////
+$base-spacing: 1.5em !default;
 $alert-color: #fff6bf !default;
 $error-color: #fbe3e4 !default;
 $notice-color: #e5edf8 !default;
 $success-color: #e6efc2 !default;
-$base-spacing: 1.5em !default;
-//////////////////////////////////////////////////////////////////////////////////
 
 @mixin flash($color) {
   background-color: $color;
   color: darken($color, 60%);
   display: block;
-  font-weight: bold;
+  font-weight: 600;
   margin-bottom: $base-spacing / 2;
   padding: $base-spacing / 2;
   text-align: center;
 
   a {
-    border-bottom: 1px solid transparentize(darken($color, 70%), 0.7);
     color: darken($color, 70%);
-    text-decoration: none;
 
     &:focus,
     &:hover {


### PR DESCRIPTION
### Badges
- Refactor to a mixin, just like the flashes
- More meaningful, concise class names (no more `.error`, etc.)
- Cuts way down on the amount of variables required

### Flashes
- Remove Sass comments (no need, they are breaking up different sets of variables)
- Remove font-smoothing
- Remove fancy bottom border and use default text underline for `a`