### PR TITLE
Change to overflow auto

### DIFF
--- a/source/stylesheets/_refills-nav.scss
+++ b/source/stylesheets/_refills-nav.scss
@@ -63,7 +63,9 @@ section.inner-content {
   @include position(fixed, 0 auto 0 0);
   @include size(220px 100%);
   @include transform(translateX(-220px));
+  @include transition(all 0.2s linear);
   background-color: black;
+  overflow-y: auto;
   -webkit-font-smoothing: antialiased;
   -webkit-overflow-scrolling: touch;
   overflow-y: scroll;

--- a/source/stylesheets/_refills-nav.scss
+++ b/source/stylesheets/_refills-nav.scss
@@ -68,7 +68,6 @@ section.inner-content {
   overflow-y: auto;
   -webkit-font-smoothing: antialiased;
   -webkit-overflow-scrolling: touch;
-  overflow-y: scroll;
   transition: all 0.2s linear;
   z-index: 999999;
 

--- a/source/stylesheets/refills/_sliding-menu.scss
+++ b/source/stylesheets/refills/_sliding-menu.scss
@@ -31,7 +31,7 @@
   @include transition(all 0.25s linear);
   background: $sliding-menu-background;
   z-index: 999999;
-  overflow-y: scroll;
+  overflow-y: auto;
   -webkit-overflow-scrolling: touch;
 
   li a {


### PR DESCRIPTION
Will this work as well on iPhones as the previous `scroll` did?
The aim here is to avoid the ugly scrollbars on the sliding menu's (if they are not needed)