### PR TITLE
Refactor serif type system

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 
 ## Requirements
 
-- [Sass](https://github.com/sass/sass) 3.3+
-- [Bourbon](https://github.com/thoughtbot/bourbon) 4.0+
-- [Neat](https://github.com/thoughtbot/neat) 1.6+
+- [Sass](https://github.com/sass/sass) 3.4+
+- [Bourbon](https://github.com/thoughtbot/bourbon) 4.1+
+- [Neat](https://github.com/thoughtbot/neat) 1.7+
 
 ## Installation
 

--- a/source/_type_system_serif.html.erb
+++ b/source/_type_system_serif.html.erb
@@ -1,19 +1,16 @@
 <head>
-  <link href='http://fonts.googleapis.com/css?family=Lusitana:400,700' rel='stylesheet' type='text/css'>
-  <link href='http://fonts.googleapis.com/css?family=Merriweather:400,300,300italic,400italic,700,700italic,900,900italic' rel='stylesheet' type='text/css'>
-  <link href='http://fonts.googleapis.com/css?family=Merriweather+Sans:400,300,300italic,400italic,700italic,700,800,800italic' rel='stylesheet' type='text/css'>
+  <link href="http://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic|Quattrocento+Sans" rel="stylesheet">
 </head>
 
-<article class="type-system-serif">
-  <p class="type">Article Type</p>
-  <h1>Article Heading</h1>
-  <h2>These override some of the styles specified in the <code>_variables.scss</code> and <code>_typography.scss</code> partials in <a href="//bitters.bourbon.io">Bitters</a>. You can replace the typography variables and the header font specifications in Bitters with these styles. Then you won&rsquo;t need the wrapping class <code>.type-system-name</code>.</h2>
-  <p class="date">30 Mar 2014</p>
-  <p><span>Lorem ipsum dolor sit amet</span>, consectetur adipisicing elit. Consequatur a, ullam, voluptatum incidunt neque doloremque vel inventore distinctio laudantium harum</a> illo quam nulla dolor alias iure impedit! Accusamus! Lorem ipsum dolor sit amet, consectetur adipisicing elit. Accusamus! Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequatur, a, ullam, voluptatum incidunt neque porro numquam doloremque vel inventore distinctio laudantium harum illo quam nulla dolor alias iure impedit.
-    <a href="javascript:void(0)" class="read-more">Read More <span>&rsaquo;</span></a>
-  </p>
-  <h3>Subheading lorem</h3>
-  <p><span>Consequatur ullam, voluptatum</span> incidunt neque porro numquam doloremque vel inventore distinctio laudantium harum illo quam nulla dolor alias iure impedit. Accusamus. Consequatur, a, ullam, voluptatum incidunt neque porro numquam doloremque vel inventore distinctio laudantium harum illo quam nulla dolor alias iure impedit! Accusamus.</p>
+<article class="type-system-serif" role="article">
+  <h1 class="article-title">Article Title</h1>
+  <div class="article-meta-info">
+    <time class="article-date" datetime="2015-01-01">January 1, 2015</time>
+    <span class="article-author">Bryan Jacobs</span>
+  </div>
+  <p class="article-intro">Rights-based approach making progress respond disruptor participatory monitoring innovation, emergent engage achieve think tank growth women and children raise awareness.</p>
+  <p>Promising development; facilitate cross-cultural long-term, enabler; accelerate life-expectancy; Millennium Development Goals inclusive. Improving quality cross-agency coordination safeguards, social challenges foundation nonviolent resistance community health workers development social entrepreneurship community time of extraordinary change.</p>
   <hr>
-  <p class="author">Author Name</p>
+  <h2>Truth Bloomberg complexity nutrition</h2>
+  <p>Cause worldwide; human rights cooperation human potential respect shift. Angelina Jolie; Bill and Melinda Gates; effect crowdsourcing <a href="http://en.wikipedia.org/wiki/John_Lennon">John Lennon</a> medicine progressive. Non-partisan, social movement Jane Jacobs prevention carbon rights; vulnerable population integrity catalytic effect tackling UNICEF empowerment connect best practices.</p>
 </article>

--- a/source/stylesheets/refills/_type-system-serif.scss
+++ b/source/stylesheets/refills/_type-system-serif.scss
@@ -1,17 +1,57 @@
-article.type-system-serif {
-  ///////////////////////////////////////////////////////////////////////////////////
-  $base-border-radius: 3px !default;
-  $base-line-height: 1.5em !default;
-  $base-spacing: 1.5em !default;
-  $base-accent-color: #477DCA !default;
-  $base-link-color: $base-accent-color !default;
-  $dark-gray: #333 !default;
-  $light-gray: #DDD !default;
-  $medium-screen: em(640) !default;
-  $base-font-color: $dark-gray !default;
-  
-  h1, h2, h3, p {
-    margin: 0;
+$dark-gray: #333 !default;
+$light-gray: #ddd !default;
+$base-font-color: $dark-gray !default;
+$base-link-color: #477dca !default;
+$sans-serif: "Quattrocento Sans", $helvetica !default;
+$serif: "Lora" !default;
+$modular-scale-ratio: $major-third !default;
+$base-line-height: 1.6 !default;
+$heading-line-height: 1.1 !default;
+$base-spacing: $base-line-height * 1.4em !default;
+
+.type-system-serif {
+  color: $base-font-color;
+  font-family: $serif;
+  line-height: $base-line-height;
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    line-height: $heading-line-height;
+    margin: ($base-spacing / 1.5) 0 ($base-spacing / 3);
+  }
+
+  h1 {
+    font-size: modular-scale(4);
+  }
+
+  h2 {
+    font-size: modular-scale(2);
+  }
+
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-size: modular-scale(1);
+  }
+
+  p {
+    margin: 0 0 ($base-spacing / 1.5);
+  }
+
+  a {
+    color: $base-link-color;
+    transition: color 0.1s ease-in-out;
+
+    &:active,
+    &:focus,
+    &:hover {
+      color: $base-font-color;
+    }
   }
 
   hr {
@@ -19,127 +59,31 @@ article.type-system-serif {
     border-left: none;
     border-right: none;
     border-top: none;
-    margin: $base-spacing 0;
+    margin: ($base-spacing * 2) auto;
+    max-width: $base-spacing * 8;
   }
 
-  p {
-    color: $base-font-color;
-    line-height: $base-line-height;
+  .article-title {
+    text-align: center;
   }
 
-  a {
-    color: $base-link-color;
-    text-decoration: none;
+  .article-intro {
+    font-size: modular-scale(1);
+    font-style: italic;
+    line-height: $base-line-height * 0.9;
+    margin-top: $base-spacing;
   }
-  //////////////////////////////////////////////////////////////////////////////////
 
-  $serif: 'Lusitana', serif;
-  $serif-2: 'Merriweather', serif;
-  $sans-serif: 'Merriweather Sans', sans-serif;
-
-  @include clearfix;
-  text-align: left;
-
-  .type {
-    border-bottom: 1px solid;
-    display: inline-block;
+  .article-meta-info {
+    color: tint($base-font-color, 25%);
     font-family: $sans-serif;
-    font-size: 0.7em;
-    font-weight: 700;
-    margin-bottom: 2em;
-    padding: 0.3em 0;
-    text-align: left;
-    text-transform: uppercase;
+    font-size: modular-scale(0);
+    text-align: center;
   }
 
-  h1 {
-    font-family: $serif;
-    font-size: 2em;
-    font-weight: 700;
-    margin-bottom: 0.5em;
-
-    @include media($medium-screen) {
-      font-size: 2.6em;
-    }
-  }
-
-  h2 {
-    font-family: $serif-2;
-    font-size: 1em;
-    font-style: italic;
-    font-weight: 400;
-    line-height: 1.6em;
-    margin-bottom: 0.9em;
-
-    @include media($medium-screen) {
-      font-size: 1.2em;
-    }
-  }
-
-  code {
-    background: #F7F7F7;
-    border-radius: $base-border-radius * 1.5;
-    border: 1px solid #E0E0E0;
-    font-family: monaco;
-    font-size: 0.75em;
-    font-style: normal;
-    padding: 0.1em 0.4em;
-    white-space: nowrap;
-  }
-
-  h3 {
-    font-family: $serif;
-    font-size: 1.4em;
-    font-weight: 400;
-    line-height: 1.3em;
-    margin-bottom: .4em;
-  }
-
-  p.date {
-    color: transparentize($base-font-color, .6);
-    font-family: $serif-2;
-    font-size: 0.9em;
-    font-style: italic;
-    margin-bottom: 0.3em;
-  }
-
-  p {
-    font-family: $serif-2;
-    font-size: 0.9em;
-    line-height: 1.6em;
-    margin-bottom: 1.5em;
-
-    span {
-      font-family: $sans-serif;
-      font-weight: 700;
-    }
-  }
-
-  a.read-more {
-    display: inline-block;
-    font-family: $sans-serif;
-    font-size: 0.8em;
-    font-weight: 700;
-    margin-left: 0.2em;
-    position: relative;
-    text-transform: uppercase;
-
-    span {
-      font-family: $serif;
-      font-size: 1.5em;
-      font-style: normal;
-      position: absolute;
-      right: -12px;
-      top: -1px;
-    }
-  }
-  
-  hr {
-    width: 3em;
-  }
-
-  p.author {
-    font-family: $serif-2;
-    font-style: italic;
+  .article-date::after {
+    @include padding(null 0.25em null 0.5em);
+    color: tint($base-font-color, 50%);
+    content: "•";
   }
 }


### PR DESCRIPTION
- Reduce bloat:
  - Remove 3 Google fonts, with 3 separate HTTP requests in favor of 2 Google fonts in a single request
  - Cut down Sass by 40%
- Remove overly-qualified CSS selectors
- More semantic HTML
- Add ARIA role
- Align with style guide

Updated design:

![type-system](https://cloud.githubusercontent.com/assets/903327/5732773/17597b7c-9b66-11e4-8471-7ae4f7936f69.png)
