### PR TITLE
Fix for allowing checkbox elements to display within a modal window.

### DIFF
--- a/source/stylesheets/refills/_modal.scss
+++ b/source/stylesheets/refills/_modal.scss
@@ -11,7 +11,7 @@
   $medium-screen: em(640) !default;
   $large-screen: em(860) !default;
   $base-font-color: $dark-gray !default;
-  
+
   h1 {
     margin: 0;
   }
@@ -40,7 +40,7 @@
     max-width: $modal-trigger-image-width;
   }
 
-  input[type="checkbox"] {
+  .modal-state {
     display: none;
   }
 


### PR DESCRIPTION
It appears that since you are using the hidden checkbox to check against the "checked" state or not to show the modal, that all other checkboxes are also hidden inside of the modal. I propose a fix for this by replacing the input[type="checkbox"] selector with .modal state. This maintains little specification while ensuring that only the correct checkbox is hidden. Feel free to reject this pull request and go with another solution you see fit. I thought I would try, at least. 