### PR TITLE
Coffeescript generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 Gemfile.lock
 pkg
 tmp/
+node_modules/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,14 @@ that variables should be interdependent to enable quick restyling.
 }
 ```
 
+## JavaScript
+
+If you change any JavaScript, please run `rake coffee` afterwards to
+generate the corresponding CoffeScript.
+
+**NOTE** - do not manually change any of the CoffeeScript files, they are
+automatically generated with `js2coffee`.
+
 ## Build
 
 If you rename/remove/add any files to the repository, please make sure that the

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Alternative to copy-pasting manually, we also have a Refills gem that allows you
   rails generate refills:import SNIPPET
   ```
 
+  If you want to generate coffeescript instead of javascript, simply add `--coffee`
+
+  ```bash
+  rails generate refills:import SNIPPET --coffee
+  ```
+
   This copies the snippet’s partial to `app/views/refills`, the stylesheet to `app/assets/stylesheets/refills` and the JavaScript to `app/assets/javascripts/refills`
 
 ## Miscellaneous

--- a/Rakefile
+++ b/Rakefile
@@ -4,5 +4,19 @@ require 'middleman-gh-pages'
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 
+desc "Compile javascript -> coffeescript"
+task :coffee do
+  destination = "source/javascripts/refills/coffeescript"
+  Dir["source/javascripts/refills/**/*.js"].each do |source|
+    filename = File.basename(source.gsub(/.js/, ".coffee"))
+
+    `$(npm bin)/js2coffee #{source} > #{destination}/#{filename}`
+  end
+
+  puts "Please make sure that all generated coffeescript files are correct"
+  puts "before committing the changes\n"
+  puts `git status`
+end
+
 task default: :spec
 task publish: :spec

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+# Exit if any subcommand fails
+set -e
+
+# Set up Ruby dependencies via Bundler
+bundle install
+
+# Add binstubs to PATH via export PATH=".git/safe/../../bin:$PATH" in ~/.zshenv
+mkdir -p .git/safe
+
+# Install js2coffee
+npm install --save-dev js2coffee

--- a/lib/refills/import_generator.rb
+++ b/lib/refills/import_generator.rb
@@ -5,6 +5,7 @@ module Refills
     desc 'Copy refills'
     source_root File.expand_path("../../../source", __FILE__)
     argument :snippet, type: :string, required: true
+    class_option :coffee, type: :boolean, default: false
 
     def copy_html
       copy_file_if_exists(
@@ -22,7 +23,7 @@ module Refills
 
     def copy_javascripts
       copy_file_if_exists(
-        File.join('javascripts', 'refills', javascript_name),
+        javascript_path,
         File.join('app', 'assets', 'javascripts', 'refills', javascript_name),
       )
     end
@@ -44,7 +45,36 @@ module Refills
     end
 
     def javascript_name
-      "#{snippet.underscore}.js"
+      "#{snippet.underscore}.#{javascript_extension}"
+    end
+
+    def javascript_extension
+      if coffee?
+        "coffee"
+      else
+        "js"
+      end
+    end
+
+    def javascript_path
+      if coffee?
+        File.join(
+          "javascripts",
+          "refills",
+          "coffeescript",
+          javascript_name
+        )
+      else
+        File.join(
+          "javascripts",
+          "refills",
+          javascript_name
+        )
+      end
+    end
+
+    def coffee?
+      options[:coffee]
     end
   end
 end

--- a/lib/snippet_helpers.rb
+++ b/lib/snippet_helpers.rb
@@ -45,6 +45,22 @@ module SnippetHelpers
     end
   end
 
+  class CoffeeScriptSnippet < Snippet
+    def path_segments
+      [
+        SOURCE_DIR,
+        "javascripts",
+        "refills",
+        "coffeescript",
+        "#{name.underscore}.coffee"
+      ]
+    end
+
+    def language
+      :javascript
+    end
+  end
+
   def code_for(snippet_name)
     partial 'code', locals: { snippets: snippets_for(snippet_name) }
   end
@@ -52,17 +68,21 @@ module SnippetHelpers
   private
 
   def snippets_for(name)
-    [HtmlSnippet, ScssSnippet, JavaScriptSnippet].map do |snippet_factory|
-      snippet = snippet_factory.new(name)
-      render_snippet snippet.path, snippet.language
+    [
+      HtmlSnippet,
+      ScssSnippet,
+      JavaScriptSnippet,
+      CoffeeScriptSnippet,
+    ].map do |snippet_factory|
+      render_snippet snippet_factory.new(name)
     end.join("\n")
   end
 
-  def render_snippet(path, language)
-    if File.exists?(path)
+  def render_snippet(snippet)
+    if File.exists?(snippet.path)
       partial 'snippet', locals: {
-        snippet: File.read(path),
-        language: language,
+        snippet: File.read(snippet.path),
+        language: snippet.language
       }
     end
   end

--- a/refills.gemspec
+++ b/refills.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.license       = 'MIT'
 
   s.files         = `git ls-files`.split($/)
-  s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']
 

--- a/source/_snippet.html.erb
+++ b/source/_snippet.html.erb
@@ -1,9 +1,13 @@
 <td class="snippet">
-  <% if language == :javascript -%>
-    <a href="javascript:void(0)" class="copy-source">Copy JavaScript</a>
-    <a href="javascript:void(0)" class="copy-source copy-coffee">Copy CoffeeScript</a>
-  <% else -%>
-    <a href="javascript:void(0)" class="copy-source">Copy</a>
-  <% end -%>
+  <div class="copy-source-container">
+    <% if language == :javascript -%>
+      <a href="javascript:void(0)" class="copy-source">Copy JavaScript</a>
+      <a href="javascript:void(0)" class="copy-source copy-coffee">Copy CoffeeScript</a>
+    <% elsif language == :markup -%>
+      <a href="javascript:void(0)" class="copy-source">Copy HTML</a>
+    <% else -%>
+      <a href="javascript:void(0)" class="copy-source">Copy Scss</a>
+    <% end -%>
+  </div>
   <pre><code class="language-<%= language %>"><%== snippet %></code></pre>
 </td>

--- a/source/_snippet.html.erb
+++ b/source/_snippet.html.erb
@@ -1,4 +1,9 @@
 <td class="snippet">
-  <a href="#" class="copy-source">Copy</a>
+  <% if language == :javascript -%>
+    <a href="javascript:void(0)" class="copy-source">Copy JavaScript</a>
+    <a href="javascript:void(0)" class="copy-source copy-coffee">Copy CoffeeScript</a>
+  <% else -%>
+    <a href="javascript:void(0)" class="copy-source">Copy</a>
+  <% end -%>
   <pre><code class="language-<%= language %>"><%== snippet %></code></pre>
 </td>

--- a/source/javascripts/all.js
+++ b/source/javascripts/all.js
@@ -1,4 +1,8 @@
-//= require_tree .
+//= require jquery.erToc
+//= require jquery.glide
+//= require menuAnchorAnimation
+//= require_directory ./vendor
+//= require_directory ./refills
 
 $(document).ready(function() {
   $('#example').erToc({'goTopNode':'#example', 'startLevel': 'h2', 'numberedSuffix':'. '});

--- a/source/javascripts/refills/coffeescript/accordion.coffee
+++ b/source/javascripts/refills/coffeescript/accordion.coffee
@@ -1,0 +1,6 @@
+$(".js-accordion-trigger").bind "click", (e) ->
+  jQuery(this).parent().find(".submenu").slideToggle "fast" # apply the toggle to the ul
+  jQuery(this).parent().toggleClass "is-expanded"
+  e.preventDefault()
+  return
+

--- a/source/javascripts/refills/coffeescript/accordion_tabs.coffee
+++ b/source/javascripts/refills/coffeescript/accordion_tabs.coffee
@@ -1,0 +1,19 @@
+$(document).ready ->
+  $(".accordion-tabs").each (index) ->
+    $(this).children("li").first().children("a").addClass("is-active").next().addClass("is-open").show()
+    return
+
+  $(".accordion-tabs").on "click", "li > a", (event) ->
+    unless $(this).hasClass("is-active")
+      event.preventDefault()
+      accordionTabs = $(this).closest(".accordion-tabs")
+      accordionTabs.find(".is-open").removeClass("is-open").hide()
+      $(this).next().toggleClass("is-open").toggle()
+      accordionTabs.find(".is-active").removeClass "is-active"
+      $(this).addClass "is-active"
+    else
+      event.preventDefault()
+    return
+
+  return
+

--- a/source/javascripts/refills/coffeescript/accordion_tabs_minimal.coffee
+++ b/source/javascripts/refills/coffeescript/accordion_tabs_minimal.coffee
@@ -1,0 +1,19 @@
+$(document).ready ->
+  $(".accordion-tabs-minimal").each (index) ->
+    $(this).children("li").first().children("a").addClass("is-active").next().addClass("is-open").show()
+    return
+
+  $(".accordion-tabs-minimal").on "click", "li > a", (event) ->
+    unless $(this).hasClass("is-active")
+      event.preventDefault()
+      accordionTabs = $(this).closest(".accordion-tabs-minimal")
+      accordionTabs.find(".is-open").removeClass("is-open").hide()
+      $(this).next().toggleClass("is-open").toggle()
+      accordionTabs.find(".is-active").removeClass "is-active"
+      $(this).addClass "is-active"
+    else
+      event.preventDefault()
+    return
+
+  return
+

--- a/source/javascripts/refills/coffeescript/centered_navigation.coffee
+++ b/source/javascripts/refills/coffeescript/centered_navigation.coffee
@@ -1,0 +1,13 @@
+$(document).ready ->
+  menuToggle = $("#js-centered-navigation-mobile-menu").unbind()
+  $("#js-centered-navigation-menu").removeClass "show"
+  menuToggle.on "click", (e) ->
+    e.preventDefault()
+    $("#js-centered-navigation-menu").slideToggle ->
+      $("#js-centered-navigation-menu").removeAttr "style"  if $("#js-centered-navigation-menu").is(":hidden")
+      return
+
+    return
+
+  return
+

--- a/source/javascripts/refills/coffeescript/dropdown.coffee
+++ b/source/javascripts/refills/coffeescript/dropdown.coffee
@@ -1,0 +1,15 @@
+$(document).ready ->
+  $(".dropdown-button").click ->
+    $(".dropdown-menu").toggleClass "show-menu"
+    $(".dropdown-menu > li").click ->
+      $(".dropdown-menu").removeClass "show-menu"
+      return
+
+    $(".dropdown-menu.dropdown-select > li").click ->
+      $(".dropdown-button").html $(this).html()
+      return
+
+    return
+
+  return
+

--- a/source/javascripts/refills/coffeescript/expander.coffee
+++ b/source/javascripts/refills/coffeescript/expander.coffee
@@ -1,0 +1,9 @@
+$(document).ready ->
+  expanderTrigger = document.getElementById("js-expander-trigger")
+  expanderContent = document.getElementById("js-expander-content")
+  $("#js-expander-trigger").click ->
+    $(this).toggleClass "expander-hidden"
+    return
+
+  return
+

--- a/source/javascripts/refills/coffeescript/fade_in.coffee
+++ b/source/javascripts/refills/coffeescript/fade_in.coffee
@@ -1,0 +1,20 @@
+$(document).ready ->
+  element = document.getElementById("js-fadeInElement")
+  $(element).addClass "js-fade-element-hide"
+  $(window).scroll ->
+    if $("#js-fadeInElement").length > 0
+      elementTopToPageTop = $(element).offset().top
+      windowTopToPageTop = $(window).scrollTop()
+      windowInnerHeight = window.innerHeight
+      elementTopToWindowTop = elementTopToPageTop - windowTopToPageTop
+      elementTopToWindowBottom = windowInnerHeight - elementTopToWindowTop
+      distanceFromBottomToAppear = 300
+      if elementTopToWindowBottom > distanceFromBottomToAppear
+        $(element).addClass "js-fade-element-show"
+      else if elementTopToWindowBottom < 0
+        $(element).removeClass "js-fade-element-show"
+        $(element).addClass "js-fade-element-hide"
+    return
+
+  return
+

--- a/source/javascripts/refills/coffeescript/navigation.coffee
+++ b/source/javascripts/refills/coffeescript/navigation.coffee
@@ -1,0 +1,13 @@
+$(document).ready ->
+  menuToggle = $("#js-mobile-menu").unbind()
+  $("#js-navigation-menu").removeClass "show"
+  menuToggle.on "click", (e) ->
+    e.preventDefault()
+    $("#js-navigation-menu").slideToggle ->
+      $("#js-navigation-menu").removeAttr "style"  if $("#js-navigation-menu").is(":hidden")
+      return
+
+    return
+
+  return
+

--- a/source/javascripts/refills/coffeescript/parallax.coffee
+++ b/source/javascripts/refills/coffeescript/parallax.coffee
@@ -1,0 +1,22 @@
+parallax = ->
+  if $("#js-parallax-window").length > 0
+    plxBackground = $("#js-parallax-background")
+    plxWindow = $("#js-parallax-window")
+    plxWindowTopToPageTop = $(plxWindow).offset().top
+    windowTopToPageTop = $(window).scrollTop()
+    plxWindowTopToWindowTop = plxWindowTopToPageTop - windowTopToPageTop
+    plxBackgroundTopToPageTop = $(plxBackground).offset().top
+    windowInnerHeight = window.innerHeight
+    plxBackgroundTopToWindowTop = plxBackgroundTopToPageTop - windowTopToPageTop
+    plxBackgroundTopToWindowBottom = windowInnerHeight - plxBackgroundTopToWindowTop
+    plxSpeed = 0.35
+    plxBackground.css "top", -(plxWindowTopToWindowTop * plxSpeed) + "px"
+  return
+$(document).ready ->
+  parallax()  if $("#js-parallax-window").length
+  return
+
+$(window).scroll (e) ->
+  parallax()  if $("#js-parallax-window").length
+  return
+

--- a/source/javascripts/refills/coffeescript/scroll_on_page.coffee
+++ b/source/javascripts/refills/coffeescript/scroll_on_page.coffee
@@ -1,0 +1,23 @@
+((jQuery) ->
+  jQuery.mark = jump: (options) ->
+    defaults = selector: "a.scroll-on-page-link"
+    defaults.selector = options  if typeof options is "string"
+    options = jQuery.extend(defaults, options)
+    jQuery(options.selector).click (e) ->
+      jumpobj = jQuery(this)
+      target = jumpobj.attr("href")
+      thespeed = 1000
+      offset = jQuery(target).offset().top
+      jQuery("html,body").animate
+        scrollTop: offset
+      , thespeed, "swing"
+      e.preventDefault()
+      return
+
+
+  return
+) jQuery
+jQuery ->
+  jQuery.mark.jump()
+  return
+

--- a/source/javascripts/refills/coffeescript/search_tools.coffee
+++ b/source/javascripts/refills/coffeescript/search_tools.coffee
@@ -1,0 +1,85 @@
+Filter = (->
+  Filter = (element) ->
+    @_element = $(element)
+    @_optionsContainer = @_element.find(@constructor.optionsContainerSelector)
+    return
+  Filter.selector = ".filter"
+  Filter.optionsContainerSelector = "> div"
+  Filter.hideOptionsClass = "hide-options"
+  Filter.enhance = ->
+    klass = this
+    $(klass.selector).each ->
+      new klass(this).enhance()
+
+
+  Filter::enhance = ->
+    @_buildUI()
+    @_bindEvents()
+    return
+
+  Filter::_buildUI = ->
+    @_summaryElement = $("<label></label>").addClass("summary").attr("data-role", "summary").prependTo(@_optionsContainer)
+    @_clearSelectionButton = $("<button></button>").text("Clear").attr("type", "button").insertAfter(@_summaryElement)
+    @_optionsContainer.addClass @constructor.hideOptionsClass
+    @_updateSummary()
+    return
+
+  Filter::_bindEvents = ->
+    self = this
+    @_summaryElement.click ->
+      self._toggleOptions()
+      return
+
+    @_clearSelectionButton.click ->
+      self._clearSelection()
+      return
+
+    @_checkboxes().change ->
+      self._updateSummary()
+      return
+
+    $("body").click (e) ->
+      inFilter = $(e.target).closest(self.constructor.selector).length > 0
+      self._allOptionsContainers().addClass self.constructor.hideOptionsClass  unless inFilter
+      return
+
+    return
+
+  Filter::_toggleOptions = ->
+    @_allOptionsContainers().not(@_optionsContainer).addClass @constructor.hideOptionsClass
+    @_optionsContainer.toggleClass @constructor.hideOptionsClass
+    return
+
+  Filter::_updateSummary = ->
+    summary = "All"
+    checked = @_checkboxes().filter(":checked")
+    summary = @_labelsFor(checked).join(", ")  if checked.length > 0
+    @_summaryElement.text summary
+    return
+
+  Filter::_clearSelection = ->
+    @_checkboxes().each ->
+      $(this).prop "checked", false
+      return
+
+    @_updateSummary()
+    return
+
+  Filter::_checkboxes = ->
+    @_element.find ":checkbox"
+
+  Filter::_labelsFor = (inputs) ->
+    inputs.map(->
+      id = $(this).attr("id")
+      $("label[for='" + id + "']").text()
+    ).get()
+
+  Filter::_allOptionsContainers = ->
+    $ @constructor.selector + " " + @constructor.optionsContainerSelector
+
+  Filter
+)()
+$ ->
+  Filter.enhance()
+  return
+

--- a/source/javascripts/refills/coffeescript/sliding_menu.coffee
+++ b/source/javascripts/refills/coffeescript/sliding_menu.coffee
@@ -1,0 +1,8 @@
+$(document).ready ->
+  $(".js-menu-trigger,.js-menu-screen").on "click touchstart", (e) ->
+    $(".js-menu,.js-menu-screen").toggleClass "is-visible"
+    e.preventDefault()
+    return
+
+  return
+

--- a/source/javascripts/refills/coffeescript/vertical_tabs.coffee
+++ b/source/javascripts/refills/coffeescript/vertical_tabs.coffee
@@ -1,0 +1,28 @@
+$(".js-vertical-tab-content").hide()
+$(".js-vertical-tab-content:first").show()
+
+# if in tab mode 
+$(".js-vertical-tab").click (event) ->
+  event.preventDefault()
+  $(".js-vertical-tab-content").hide()
+  activeTab = $(this).attr("rel")
+  $("#" + activeTab).show()
+  $(".js-vertical-tab").removeClass "is-active"
+  $(this).addClass "is-active"
+  $(".js-vertical-tab-accordion-heading").removeClass "is-active"
+  $(".js-vertical-tab-accordion-heading[rel^='" + activeTab + "']").addClass "is-active"
+  return
+
+
+# if in accordion mode 
+$(".js-vertical-tab-accordion-heading").click (event) ->
+  event.preventDefault()
+  $(".js-vertical-tab-content").hide()
+  accordion_activeTab = $(this).attr("rel")
+  $("#" + accordion_activeTab).show()
+  $(".js-vertical-tab-accordion-heading").removeClass "is-active"
+  $(this).addClass "is-active"
+  $(".js-vertical-tab").removeClass "is-active"
+  $(".js-vertical-tab[rel^='" + accordion_activeTab + "']").addClass "is-active"
+  return
+

--- a/source/refills-page-scripts.html.erb
+++ b/source/refills-page-scripts.html.erb
@@ -42,7 +42,15 @@
   $(document).ready( function() {
     client = new ZeroClipboard($('.copy-source'), {moviePath: '/images/ZeroClipboard.swf'})
     client.on('dataRequested', function(client, args) {
-      code = $(this).siblings('pre').text();
+      var code;
+      if ($(this).hasClass("copy-coffee")) {
+        var row = $(this).parent().parent();
+        var coffee = row.find("td.snippet").last();
+
+        code = coffee.children("pre").text();
+      } else {
+        code = $(this).siblings("pre").text();
+      }
       client.setText(code);
     });
   });

--- a/source/refills-page-scripts.html.erb
+++ b/source/refills-page-scripts.html.erb
@@ -42,15 +42,13 @@
   $(document).ready( function() {
     client = new ZeroClipboard($('.copy-source'), {moviePath: '/images/ZeroClipboard.swf'})
     client.on('dataRequested', function(client, args) {
-      var code;
       if ($(this).hasClass("copy-coffee")) {
-        var row = $(this).parent().parent();
-        var coffee = row.find("td.snippet").last();
-
-        code = coffee.children("pre").text();
+        var cell = $(this).parents("tr").find("td.snippet").last();
       } else {
-        code = $(this).siblings("pre").text();
+        var cell = $(this).parents("td.snippet");
       }
+
+      var code = cell.children("pre").text();
       client.setText(code);
     });
   });

--- a/source/stylesheets/_refills-styles.scss
+++ b/source/stylesheets/_refills-styles.scss
@@ -35,6 +35,8 @@ $refills-hero-background: #e7f1ec;
 $refills-highlight-color: #bbb295;
 $refills-narrow-sans: "Oswald", sans-serif;
 $refills-white-shadow: 0 1px 1px transparentize(#fff, 0.6);
+$refills-medium-screen: em(640);
+$refills-large-screen: em(860);
 
 $refills-serif: "Lusitana", $georgia;
 $refills-second-serif: $georgia;
@@ -52,8 +54,6 @@ body {
 }
 
 .refills-header {
-  $refills-medium-screen: em(640);
-  $refills-large-screen: em(860);
   @extend .refills-header;
   @include clearfix;
   background-color: $refills-hero-background;
@@ -162,8 +162,6 @@ body {
 // Refill menu
 
 ul.refills-menu {
-  $refills-medium-screen: em(640) !default;
-  $refills-large-screen: em(860) !default;
   font-weight: normal;
   margin-bottom: 5em;
   margin: -3.3em auto 0 auto;
@@ -376,22 +374,6 @@ pre[class*="language-"] {
   line-height: 1em;
 }
 
-.copy-source {
-  background-color: lighten(#333, 20%);
-  border-radius: 10px;
-  color: #fff;
-  font-size: 0.5em;
-  font-weight: 800;
-  padding: 0.4em 1em;
-  text-transform: uppercase;
-
-  &:hover,
-  &:active {
-    background-color: lighten(#333, 20%);
-    color: #fff;
-  }
-}
-
 .snippets-table {
   display: none;
 
@@ -404,8 +386,52 @@ pre[class*="language-"] {
   }
 }
 
+
 .snippet {
-  $refills-medium-screen: em(640) !default;
+  .copy-source-container {
+    min-height: 3.4em;
+
+    @include media($refills-medium-screen) {
+      min-height: 2.5em;
+    }
+
+    @include media($refills-large-screen) {
+      min-height: 1em;
+    }
+  }
+
+  &:nth-of-type(1) .copy-source {
+    background: #e98065;     
+  }
+
+  &:nth-of-type(2) .copy-source {
+    background: #55a1d4;     
+  }
+
+  &:nth-of-type(3) .copy-source:nth-of-type(1) {
+    background: #e9c05b;     
+  }
+
+  &:nth-of-type(3) .copy-source:nth-of-type(2) {
+    background: #89b981;     
+  }
+
+  .copy-source {
+    border-radius: 10px;
+    border-bottom-right-radius: 0;
+    color: #fff;
+    display: inline-block;
+    font-size: 0.5em;
+    font-weight: 800;
+    padding: 0.4em 1em;
+    text-transform: uppercase;
+
+    &:hover,
+    &:active {
+      background-color: lighten(#333, 20%);
+      color: #fff;
+    }
+  }
 
   a {
     text-decoration: none;
@@ -430,9 +456,6 @@ pre[class*="language-"] {
 // Footer
 
 footer.refills-footer {
-  $refills-medium-screen: em(640) !default;
-  $refills-large-screen: em(860) !default;
-
   color: silver;
   padding-bottom: 2em;
   padding-top: 1em;
@@ -465,7 +488,6 @@ footer.refills-footer {
   }
 
   .footer-links {
-    $refills-medium-screen: em(640) !default;
     background: #f3f3f3;
     border-radius: 3em;
     box-shadow: inset 0 1px 2px darken(#f3f3f3, 6%);
@@ -498,7 +520,6 @@ footer.refills-footer {
 // Adjustments
 
 .refill-smaller {
-  $refills-large-screen: em(640);
 
   @include media($refills-large-screen) {
     margin: auto;
@@ -522,8 +543,6 @@ footer.refills-footer {
   $dark-gray: #333;
   $light-gray: #ddd;
   $refills-line-height: 1.5em;
-  $refills-medium-screen: em(640);
-  $refills-large-screen: em(860);
 
   $tab-border-color: $refills-border-color;
   $tab-border: 1px solid $tab-border-color;

--- a/source/stylesheets/_refills-styles.scss
+++ b/source/stylesheets/_refills-styles.scss
@@ -398,6 +398,10 @@ pre[class*="language-"] {
   td {
     border-bottom: 0;
   }
+
+  .snippet:nth-child(4n) {
+    display: none;
+  }
 }
 
 .snippet {

--- a/source/stylesheets/_refills-styles.scss
+++ b/source/stylesheets/_refills-styles.scss
@@ -388,6 +388,11 @@ pre[class*="language-"] {
 
 
 .snippet {
+
+  @include media($refills-medium-screen) {
+    margin-bottom: 2em;
+  }
+
   .copy-source-container {
     min-height: 3.4em;
 
@@ -417,8 +422,10 @@ pre[class*="language-"] {
   }
 
   .copy-source {
-    border-radius: 10px;
+    border-bottom-left-radius: 10px;
     border-bottom-right-radius: 0;
+    border-top-left-radius: 10px;
+    border-top-right-radius: 10px;
     color: #fff;
     display: inline-block;
     font-size: 0.5em;
@@ -435,10 +442,6 @@ pre[class*="language-"] {
 
   a {
     text-decoration: none;
-  }
-
-  @include media($refills-medium-screen) {
-    margin-bottom: 2em;
   }
 
   code {

--- a/spec/refills/import_generator_spec.rb
+++ b/spec/refills/import_generator_spec.rb
@@ -75,9 +75,27 @@ describe Refills::ImportGenerator, type: :generator do
 
     if templates.include?("js")
       it "imports JS file for #{snippet.humanize}" do
-        run_generator [ snippet ]
+        run_generator [snippet]
 
-        assert_file "app/assets/javascripts/refills/#{snippet.underscore}.js"
+        assert_file(
+          "app/assets/javascripts/refills/#{snippet.underscore}.js"
+        )
+        assert_no_file(
+          "app/assets/javascripts/refills/#{snippet.underscore}.coffee"
+        )
+      end
+
+      context "with --coffee" do
+        it "imports Coffee file for #{snippet.humanize}" do
+          run_generator [snippet, "--coffee"]
+
+          assert_file(
+            "app/assets/javascripts/refills/#{snippet.underscore}.coffee"
+          )
+          assert_no_file(
+            "app/assets/javascripts/refills/#{snippet.underscore}.js"
+          )
+        end
       end
     end
 


### PR DESCRIPTION
After a discussion with @Magnus-G about #135 we concluded that we prefered having the source files in JS and then ad-hoc generate the Coffeescript files when needed.

So I modified @seanpdoyle's PR (#135) to generate the Coffeescript files from the JS-files instead of the other way around.
This relies on the npm package `js2coffee`(I couldn't find a rubygems alternative), so `bin/setup` now installs it(amongst other things)

If you want to generate the Coffeescript files inside a project, you simply pass the `--coffee` flag to the generator.

- [x] Generate all JS files into Coffeescript
- [x] Update documentation(gh-pages) to link to both the JS and the Coffescript