### PR TITLE
Allow closing modals by clicking on background window

### DIFF
--- a/source/javascripts/refills/coffeescript/modal.coffee
+++ b/source/javascripts/refills/coffeescript/modal.coffee
@@ -6,5 +6,13 @@ $ ->
       $("body").removeClass "modal-open"
     return
 
+  $(".modal-window").on "click", ->
+    $(".modal-state:checked").prop("checked", false).change()
+    return
+
+  $(".modal-inner").on "click", (e) ->
+    e.stopPropagation()
+    return
+
   return
 

--- a/source/javascripts/refills/modal.js
+++ b/source/javascripts/refills/modal.js
@@ -6,4 +6,12 @@ $(function() {
       $("body").removeClass("modal-open");
     }
   });
+
+  $(".modal-window").on("click", function() {
+    $(".modal-state:checked").prop("checked", false).change();
+  });
+
+  $(".modal-inner").on("click", function(e) {
+    e.stopPropagation();
+  });
 });


### PR DESCRIPTION
Hi, this PR adds the ability to close modals by clocking on background window. It basically just trigger a `modal-state` checked change. StopPropagation on `modal-inner` element is needed to allow clicking inside the `modal-inner` without causing the modal to close (inner is inside window so the click would be triggered as well). Coffescript is generated with `rake coffee`.

P.S. I know you want to keep javascript as minimal as possible but I think this could be useful for someone else. I'll totally understand if this is not accepted. :smile: 