### PR TITLE
fixes modal window closing bug

### DIFF
--- a/source/javascripts/refills/coffeescript/modal.coffee
+++ b/source/javascripts/refills/coffeescript/modal.coffee
@@ -1,5 +1,5 @@
 $ ->
-  $("#modal-1").on "click", ->
+  $("#modal-1").on "change", ->
     if $(this).is(":checked")
       $("body").addClass "modal-open"
     else

--- a/source/javascripts/refills/modal.js
+++ b/source/javascripts/refills/modal.js
@@ -1,5 +1,5 @@
 $(function() {
-  $("#modal-1").on("click", function() {
+  $("#modal-1").on("change", function() {
     if ($(this).is(":checked")) {
       $("body").addClass("modal-open");
     } else {


### PR DESCRIPTION
Hi, #236 and #221 together are causing a bug (currently also on refills website :skull: ). When the modal is closed by clicking outside the modal inner the "window-open" class is not removed correctly from body. I changed the "click" binding event into "change" for the "modal-state" input. This way it will correctly close the background window, even if the modal is closed programmatically.