### PR TITLE
Makes links in flashes underlined

### DIFF
--- a/source/stylesheets/refills/_flashes.scss
+++ b/source/stylesheets/refills/_flashes.scss
@@ -15,6 +15,7 @@ $success-color: #e6efc2 !default;
 
   a {
     color: darken($color, 70%);
+    text-decoration: underline;
 
     &:focus,
     &:hover {


### PR DESCRIPTION
The example for **flashes** shows links as underlined: http://refills.bourbon.io/components/#flashes

But if someone is using bitters, links are **not** underlined (by default): https://github.com/thoughtbot/bitters/blob/master/app/assets/stylesheets/_typography.scss


I understand if you don't want to add it here, since the user should have control over their links without getting overridden, but just thought I'd offer this quick fix!