### PR TITLE
Fix <title>'s on all pages

### DIFF
--- a/source/components.html.erb
+++ b/source/components.html.erb
@@ -1,3 +1,7 @@
+---
+title: Components
+---
+
 <div class="refills-components">
 
   <a class="js-menu-trigger-refills refills-menu-anchor fixedsticky">

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -1,5 +1,5 @@
 ---
-title: Refills
+title: Patterns
 ---
 
 <div class="refills-patterns">

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="description" content="Refills are prepackaged patterns and components built with Bourbon, Neat and Bitters.">
-    <title><%= current_page.data.title %></title>
+    <title>Refills<%= " - #{ current_page.data.title}" if current_page.data.title %></title>
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Oswald:400,300,700|Lusitana:400,700|Open+Sans:400,800">
     <%= stylesheet_link_tag "all" %>
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>

--- a/source/type-systems.html.erb
+++ b/source/type-systems.html.erb
@@ -1,3 +1,7 @@
+---
+title: Type Systems
+---
+
 <div class="refills-type-systems">
 
   <a class="js-menu-trigger-refills refills-menu-anchor fixedsticky">


### PR DESCRIPTION
What this commit does:

File | `<title>` Before | `<title>` After
---|---|---
index.html.erb            |   Refills | Refills - Patterns
components.html.erb |   n/a     | Refills - Components
type-systems.html.erb |  n/a     | Refills - Type Systems


Not sure if the title for the `index.html.erb. is correct, since it's both the index and the Patterns page. 

To make it just "Refills", like it was, the front  matter for that page should be removed.