### PR TITLE
Remove `js-*` classes

### DIFF
--- a/source/_expander.html.erb
+++ b/source/_expander.html.erb
@@ -1,6 +1,6 @@
 <div class="expander">
-  <a href="javascript:void(0)" id="js-expander-trigger" class="expander-trigger expander-hidden">Expandable section</a>
-  <div id="js-expander-content" class="expander-content">
+  <a href="javascript:void(0)" class="expander-trigger expander-hidden">Expandable section</a>
+  <div class="expander-content">
     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Distinctio mollitia fugiat facilis enim accusamus quisquam aut, repellendus incidunt quod optio facere labore illo numquam ipsum beatae vero debitis, fugit excepturi.</p>
   </div>
 </div>

--- a/source/_sliding_menu.html.erb
+++ b/source/_sliding_menu.html.erb
@@ -1,8 +1,8 @@
-<button type="button" class="js-menu-trigger sliding-menu-button">
+<button type="button" class="sliding-menu-button">
   <img src="https://raw.githubusercontent.com/thoughtbot/refills/master/source/images/menu-white.png" alt="Menu Icon">
 </button>
 
-<nav class="js-menu sliding-menu-content">
+<nav class="sliding-menu-content">
   <ul>
     <li><a href="javascript:void(0)">Item 1</a></li>
     <li><a href="javascript:void(0)">Item 2</a></li>
@@ -10,4 +10,4 @@
   </ul>
 </nav>
 
-<div class="js-menu-screen sliding-menu-fade-screen"></div>
+<div class="sliding-menu-fade-screen"></div>

--- a/source/javascripts/refills/coffeescript/expander.coffee
+++ b/source/javascripts/refills/coffeescript/expander.coffee
@@ -1,9 +1,7 @@
 $(document).ready ->
-  expanderTrigger = document.getElementById("js-expander-trigger")
-  expanderContent = document.getElementById("js-expander-content")
-  $("#js-expander-trigger").click ->
-    $(this).toggleClass "expander-hidden"
+  expanderTrigger = $('.expander-trigger')
+  expanderContent = $('.expander-content')
+  expanderTrigger.click ->
+    $(this).toggleClass 'expander-hidden'
     return
-
   return
-

--- a/source/javascripts/refills/coffeescript/sliding_menu.coffee
+++ b/source/javascripts/refills/coffeescript/sliding_menu.coffee
@@ -1,8 +1,6 @@
 $(document).ready ->
-  $(".js-menu-trigger,.js-menu-screen").on "click touchstart", (e) ->
-    $(".js-menu,.js-menu-screen").toggleClass "is-visible"
+  $('.sliding-menu-button, .sliding-menu-fade-screen').on 'click touchstart', (e) ->
+    $('.sliding-menu-content, .sliding-menu-fade-screen').toggleClass 'is-visible'
     e.preventDefault()
     return
-
   return
-

--- a/source/javascripts/refills/expander.js
+++ b/source/javascripts/refills/expander.js
@@ -1,8 +1,8 @@
 $(document).ready(function() {
-  var expanderTrigger = document.getElementById("js-expander-trigger");
-  var expanderContent = document.getElementById("js-expander-content");
+  var expanderTrigger = $(".expander-trigger");
+  var expanderContent = $(".expander-content");
 
-  $('#js-expander-trigger').click(function(){
+  expanderTrigger.click(function(){
     $(this).toggleClass("expander-hidden");
   });
 });

--- a/source/javascripts/refills/sliding_menu.js
+++ b/source/javascripts/refills/sliding_menu.js
@@ -1,6 +1,6 @@
 $(document).ready(function(){
-  $('.js-menu-trigger,.js-menu-screen').on('click touchstart',function (e) {
-    $('.js-menu,.js-menu-screen').toggleClass('is-visible');
+  $('.sliding-menu-button, .sliding-menu-fade-screen').on('click touchstart',function (e) {
+    $('.sliding-menu-content, .sliding-menu-fade-screen').toggleClass('is-visible');
     e.preventDefault();
   });
 });


### PR DESCRIPTION
This is an example of the issues discussed in #234: I've removed the `js-*` classes from Expander and Sliding Menu as a demonstration of what that would look like.