### PR TITLE
Search Tools - Add right-padding, so text isn't hidden behind 'Clear' button

### DIFF
--- a/source/stylesheets/refills/_search-tools.scss
+++ b/source/stylesheets/refills/_search-tools.scss
@@ -66,6 +66,12 @@
         cursor: pointer;
         font-weight: 400;
         margin-bottom: 0;
+
+        &.summary {
+          // Give some padding for the "Clear" button
+          // This is the approximate computed width that button (plus some)
+          padding-right: 4.5em;
+        }
       }
     }
 

--- a/source/stylesheets/refills/_search-tools.scss
+++ b/source/stylesheets/refills/_search-tools.scss
@@ -1,4 +1,4 @@
-.search-tools {  
+.search-tools {
   ///////////////////////////////////////////////////////////////////////////////////
   $base-border-color: gainsboro !default;
   $base-border-radius: 3px !default;
@@ -9,7 +9,7 @@
   $dark-gray: #333 !default;
   $large-screen: em(860) !default;
   $base-font-color: $dark-gray !default;
-  
+
   ol {
     margin: 0;
     padding: 0;
@@ -25,6 +25,12 @@
     display: block;
     font-weight: bold;
     margin-bottom: $base-spacing / 4;
+
+    &.summary {
+      // Give some padding for the "Clear" button
+      // This is the approximate computed width that button (plus some)
+      padding-right: 4.5em;
+    }
   }
   //////////////////////////////////////////////////////////////////////////////////
 
@@ -66,12 +72,6 @@
         cursor: pointer;
         font-weight: 400;
         margin-bottom: 0;
-
-        &.summary {
-          // Give some padding for the "Clear" button
-          // This is the approximate computed width that button (plus some)
-          padding-right: 4.5em;
-        }
       }
     }
 


### PR DESCRIPTION
Currently, the text in Search Tools can go behind the 'Clear' button. 
(The following are examples from my dev, since the examples on the site aren't long enough to show the issue)

Notice that "Orange" is partially obscured:
![screen shot 2015-02-04 at 21 10 52](https://cloud.githubusercontent.com/assets/632942/6053803/5955f55c-acb2-11e4-92c2-4feffb510d5a.png)


By adding some `right-padding` to the top `.summary` label, we can avoid that:
![screen shot 2015-02-04 at 21 09 33](https://cloud.githubusercontent.com/assets/632942/6053810/6eecd78c-acb2-11e4-8b04-0640d4e94363.png)


Here's a view of the padding from Firebug:
![screen shot 2015-02-04 at 21 09 45](https://cloud.githubusercontent.com/assets/632942/6053805/5eac6446-acb2-11e4-83e9-604096a55789.png)


The only downside is that it looks a *little* awkward when the dropdown isn't there:
![screen shot 2015-02-04 at 21 09 56](https://cloud.githubusercontent.com/assets/632942/6053806/61a07886-acb2-11e4-977d-81727d7f9224.png)


But if we fix this (by removing the padding when `.hide-options` on the parent div is present), then the options will move around when you click the box.
