### PR TITLE
Update box to say 'All' if all checkboxes are checked

### DIFF
--- a/source/javascripts/refills/search_tools.js
+++ b/source/javascripts/refills/search_tools.js
@@ -72,7 +72,7 @@ var Filter = (function() {
     var summary = 'All';
     var checked = this._checkboxes().filter(':checked');
 
-    if (checked.length > 0) {
+    if (checked.length > 0 && checked.length < this._checkboxes().length) {
       summary = this._labelsFor(checked).join(', ');
     }
 


### PR DESCRIPTION
Right now, if all the checkboxes are selected, each `label` is listed:
![screen shot 2015-02-05 at 19 24 38](https://cloud.githubusercontent.com/assets/632942/6072470/1ee3be7c-ad70-11e4-821d-8c7cc209d790.png)

This PR makes it so that if they're all selected, the 'summary' box says "All" instead:
![screen shot 2015-02-05 at 19 27 51](https://cloud.githubusercontent.com/assets/632942/6072471/1ffba41e-ad70-11e4-9e7c-c7d5ee2aab25.png)
