### PR TITLE
Remove unused `.modal-closed` class

### DIFF
--- a/source/stylesheets/refills/_modal.scss
+++ b/source/stylesheets/refills/_modal.scss
@@ -163,8 +163,4 @@
   overflow: hidden;
 }
 
-.modal-closed {
-  overflow: auto;
-}
-
 // Based on code by Kasper Mikiewicz


### PR DESCRIPTION
The `.modal-closed` class appears to be unused. I've grep'd the repo and can't find any other references to this class.

P.S. Thanks for maintaining this great resource!