### PR TITLE
Update _footer-2.scss

### DIFF
--- a/source/stylesheets/refills/_footer-2.scss
+++ b/source/stylesheets/refills/_footer-2.scss
@@ -20,7 +20,9 @@
 //   height: 17em;
 
 //   @include media($large-screen) {
-//     height: 4em;
+//     height: 4.5em;
+//     bottom: 0;
+//     position: absolute;
 //   }
 // }
 


### PR DESCRIPTION
This scss patch ensures that footer-2 is the correct height and sits flush to the bottom of the page when in "sticky mode". Fixes #249.