### PR TITLE
Use global variable for accorion-tabs

### DIFF
--- a/source/stylesheets/refills/_accordion-tabs.scss
+++ b/source/stylesheets/refills/_accordion-tabs.scss
@@ -1,30 +1,21 @@
 .accordion-tabs {
-  ///////////////////////////////////////////////////////////////////////////////////
-  $base-border-color: gainsboro !default;
-  $base-border-radius: 3px !default;
-  $base-background-color: white !default;
-  $base-spacing: 1.5em !default;
-  $base-accent-color: #477DCA !default;
-  $base-link-color: $base-accent-color !default;
-  $dark-gray: #333 !default;
-  $light-gray: #DDD !default;
-  $medium-screen: em(640) !default;
-  //////////////////////////////////////////////////////////////////////////////////
-
-  $tab-border: 1px solid $base-border-color;
-  $tab-content-background: lighten($light-gray, 10);
-  $tab-active-background: $tab-content-background;
-  $tab-inactive-color: $base-background-color;
-  $tab-inactive-hover-color: darken($light-gray, 5);
-  $tab-mode: $medium-screen;
+  $tab-spacing:            if(global-variable-exists(base-spacing), $base-spacing, 1.5em);
+  $tab-accent-color:       if(global-variable-exists(action-color), $action-color, #477dca);
+  $tab-border:             if(global-variable-exists(base-border), $base-border, 1px solid gainsboro);
+  $tab-border-radius:      if(global-variable-exists(base-border-radius), $base-border-radius, 3px);
+  $tab-content-background: if(global-variable-exists(light-gray), lighten($light-gray, 10%), #f6f6f6);
+  $tab-inactive-color:     if(global-variable-exists(base-background-color), $base-background-color, #fff);
+  $tab-link-color:         if(global-variable-exists(dark-gray), $dark-gray, #333);
+  $tab-mode:               if(global-variable-exists(medium-screen), $medium-screen, em(640));
+  $tab-active-background:  $tab-content-background;
 
   @include clearfix;
   line-height: 1.5;
-  margin-bottom: $base-spacing;
+  margin-bottom: $tab-spacing;
   padding: 0;
 
   @include media(max-width $tab-mode) {
-    border-radius: $base-border-radius;
+    border-radius: $tab-border-radius;
     border: $tab-border;
   }
 
@@ -36,8 +27,8 @@
     }
 
     &:first-child .tab-link {
-      border-top-left-radius: $base-border-radius;
-      border-top-right-radius: $base-border-radius;
+      border-top-left-radius: $tab-border-radius;
+      border-top-right-radius: $tab-border-radius;
 
       @include media(max-width $tab-mode) {
         border-top: 0;
@@ -46,8 +37,8 @@
 
     &:last-child .tab-link {
       @include media(max-width $tab-mode) {
-        border-bottom-left-radius: $base-border-radius;
-        border-bottom-right-radius: $base-border-radius;
+        border-bottom-left-radius: $tab-border-radius;
+        border-bottom-right-radius: $tab-border-radius;
       }
     }
   }
@@ -55,21 +46,21 @@
   .tab-link {
     background-color: $tab-inactive-color;
     border-top: $tab-border;
-    color: $dark-gray;
+    color: $tab-link-color;
     display: block;
     font-weight: bold;
-    padding: $base-spacing/2 $gutter/2;
+    padding: ($tab-spacing/2) $gutter;
     text-decoration: none;
 
     @include media($tab-mode) {
       @include inline-block;
-      border-top-left-radius: $base-border-radius;
-      border-top-right-radius: $base-border-radius;
+      border-top-left-radius: $tab-border-radius;
+      border-top-right-radius: $tab-border-radius;
       border-top: 0;
     }
 
     &:hover {
-      color: $base-link-color;
+      color: $tab-accent-color;
     }
 
     &:focus {
@@ -91,13 +82,13 @@
   .tab-content {
     background: $tab-content-background;
     display: none;
-    padding: $base-spacing $gutter;
+    padding: $tab-spacing $gutter;
     width: 100%;
 
     @include media($tab-mode) {
-      border-bottom-left-radius: $base-border-radius;
-      border-bottom-right-radius: $base-border-radius;
-      border-top-right-radius: $base-border-radius;
+      border-bottom-left-radius: $tab-border-radius;
+      border-bottom-right-radius: $tab-border-radius;
+      border-top-right-radius: $tab-border-radius;
       border: $tab-border;
       float: left;
     }

--- a/source/stylesheets/refills/_accordion-tabs.scss
+++ b/source/stylesheets/refills/_accordion-tabs.scss
@@ -15,8 +15,8 @@
   padding: 0;
 
   @include media(max-width $tab-mode) {
-    border-radius: $tab-border-radius;
     border: $tab-border;
+    border-radius: $tab-border-radius;
   }
 
   .tab-header-and-content {
@@ -54,9 +54,9 @@
 
     @include media($tab-mode) {
       @include inline-block;
+      border-top: 0;
       border-top-left-radius: $tab-border-radius;
       border-top-right-radius: $tab-border-radius;
-      border-top: 0;
     }
 
     &:hover {
@@ -86,10 +86,10 @@
     width: 100%;
 
     @include media($tab-mode) {
+      border: $tab-border;
       border-bottom-left-radius: $tab-border-radius;
       border-bottom-right-radius: $tab-border-radius;
       border-top-right-radius: $tab-border-radius;
-      border: $tab-border;
       float: left;
     }
   }


### PR DESCRIPTION
This allows the use of Bitters variables **if** they are available.
If not, there is a fallback value for the variable.
The tabbing in the variables might not be according to our style guides but it makes it easier to read.

What do you think @kylefiedler, @tysongach, @kaishin?
Is this a good middle ground between Bitters and Refills?

*Sidenote why Refills should not depend on Bitters:*

Consider this scenario. It has happened a few times in the past:
- Refills depends on Bitters v1
- User gets Bitters v1
- User changes Bitters v1 locally
- Bitter gets an update. Turns into Bitters v2 remotely
- Refills updates to follow Bitters v2 instead of v1
- User copies a Refills component
- Component doesn’t work locally
- It requires Bitters v2 and not Bitters v1
- User can’t switch to Bitters v2 because the local files are all customized and changed
- Refills should not be dependent on Bitters 