### PR TITLE
Update progress bars to utilize progress html5 element.

### DIFF
--- a/source/_progress_bar.html.erb
+++ b/source/_progress_bar.html.erb
@@ -1,3 +1,1 @@
-<div class="progress-bar">
-  <span class="meter" style="width: 60%"></span>
-</div>
+<progress class="progress-bar" max="100" value="60"></progress>

--- a/source/_progress_bar_indication.html.erb
+++ b/source/_progress_bar_indication.html.erb
@@ -1,5 +1,4 @@
-<div class="progress-bar-indication">
-  <span class="meter" style="width: 60%">
-    <p>60%</p>
-  </span>
+<div class="progress-bar-with-status">
+  <progress class="progress-bar-indication" max="100" value="60"></progress>
+  <span class="progress-bar-status">60%</span>
 </div>

--- a/source/stylesheets/refills/_progress-bar-indication.scss
+++ b/source/stylesheets/refills/_progress-bar-indication.scss
@@ -1,45 +1,50 @@
-.progress-bar-indication {  
-  $base-border-color: gainsboro !default;
-  $base-border-radius: 3px !default;
-  $base-background-color: white !default;
-  $base-line-height: 1.5em !default;
-  $action-color: #477DCA !default;
-  $progress-border-color: $base-border-color;
-  $progress-border: 1px solid $progress-border-color;
-  $progress-meter-border-color: $action-color;
-  $progress-meter-border: 1px solid darken($progress-meter-border-color, 15%);
-  $progress-meter-color: $progress-meter-border-color;
-  $progress-background: darken($base-background-color, 5);
-  $progress-animation-duration: 0.7s;
-  $progress-color: white;
+.progress-bar-with-status {
+  $base-background-color: #fff !default;
+  $base-accent-color: #477dca !default;
+  $progress-background-color: darken($base-background-color, 5);
+  $progress-height: 24px;
+  $progress-status-color: $base-accent-color;
+  $progress-width: 100%;
+  $progress-border-radius: $progress-height;
 
-  background-color: $progress-background;
-  border-radius: $base-border-radius;
-  border: $progress-border;
-  box-shadow: inset 0 0 3px 0 rgba(darken($progress-background, 50%), 0.15);
-  margin: 0 auto;
-  width: 100%;
+  position: relative;
 
-  > span.meter {
-    @include box-sizing(border-box);
-    background-color: $progress-meter-color;
-    background-repeat: repeat-x;
-    background-size: 40px 40px;
-    border-bottom-right-radius: 0;
-    border-radius: $base-border-radius /1.5;
-    border-top-right-radius: 0;
-    border: $progress-meter-border;
+  .progress-bar-indication {
+    @include appearance(none);
+    background-color: $progress-background-color;
+    border: none;
+    border-radius: $progress-border-radius;
+    color: $progress-status-color;
     display: block;
-    height: 100%;
-    width: 60%;
+    height: $progress-height;
+    width: $progress-width;
+
+    &::-webkit-progress-bar {
+      background-color: $progress-background-color;
+      border-radius: $progress-border-radius;
+    }
+
+    &::-webkit-progress-value {
+      background-color: $progress-status-color;
+      border-radius: $progress-border-radius;
+    }
+
+    &::-moz-progress-bar {
+      background-color: $progress-status-color;
+      border-radius: $progress-border-radius;
+    }
+
+    &::-ms-fill {
+      background-color: $progress-status-color;
+      border: none;
+    }
   }
 
-  p {
-    color: $progress-color;    
+  .progress-bar-status {
+    @include position(absolute, 50% null null 1em);
+    @include transform(translateY(-50%));
+    color: #fff;
     font-weight: 800;
-    line-height: $base-line-height;
-    margin: 0;
-    padding: .1em .5em;
-    text-shadow: 0 0 1px black;
+    margin-top: 1px;
   }
 }

--- a/source/stylesheets/refills/_progress-bar.scss
+++ b/source/stylesheets/refills/_progress-bar.scss
@@ -1,88 +1,67 @@
 .progress-bar {
-  $base-border-color: gainsboro !default;
-  $base-background-color: white !default;
-  $base-border-radius: 3px !default;
-  $action-color: #477DCA !default;
-  $base-link-color: $action-color !default;
-  $progress-border-color: $base-border-color;
-  $progress-border: 1px solid $progress-border-color;
-  $progress-meter-border-color: $action-color;
-  $progress-meter-border: 1px solid darken($progress-meter-border-color, 15%);
-  $progress-meter-color: $progress-meter-border-color;
-  $progress-background: darken($base-background-color, 5);
+  $base-background-color: #fff !default;
+  $base-accent-color: #477dca !default;
+  $progress-background-color: darken($base-background-color, 5);
+  $progress-height: 24px;
+  $progress-status-color: $base-accent-color;
+  $progress-width: 100%;
+  $progress-border-radius: $progress-height;
   $progress-animation-duration: 0.7s;
-  $progress-height: 30px;
 
-  background-color: $progress-background;
-  border: $progress-border;
-  box-shadow: inset 0 0 3px 0 rgba(darken($progress-background, 50%), 0.15);
-  border-radius: $base-border-radius;
-  height: $progress-height;
-  margin: 0 auto;
-  padding: 2px;
-  width: 100%;
-
-  > span.meter {
+  @mixin animated-progress {
     @include animation(progress $progress-animation-duration linear infinite);
-    @include box-sizing(border-box);
-    background-color: $progress-meter-color;
     @include background-image(linear-gradient(-45deg, rgba(255,255,255, 0.15) 25%,
                                                       transparent 25%,
                                                       transparent 50%,
                                                       rgba(255,255,255, 0.15) 50%,
                                                       rgba(255,255,255, 0.15) 75%,
                                                       transparent 75%));
-    background-size: 40px 40px;
+    background-color: $base-accent-color;
     background-repeat: repeat-x;
-    border: $progress-meter-border;
-    border-radius: $base-border-radius / 1.5;
-    display: block;
-    height: 100%;
-    width: 60%;
+    background-size: 40px 40px;
+    border-radius: $progress-border-radius;
   }
-}
 
-@-webkit-keyframes progress {
-  0% {
-    background-position: 0px 0px;
-  }
-  100% {
-    background-position: 40px 0px;
-  }
-}
+  @include keyframes(progress) {
+    0% {
+      background-position: 0 0;
+    }
 
-@-moz-keyframes progress {
-  0% {
-    background-position: 0px 0px;
+    100% {
+      background-position: 40px 0;
+    }
   }
-  100% {
-    background-position: 40px 0px;
-  }
-}
 
-@-ms-keyframes progress {
-  0% {
-    background-position: 0px 0px;
-  }
-  100% {
-    background-position: 40px 0px;
-  }
-}
+  @include appearance(none);
+  @include animated-progress;
+  background-color: $progress-background-color;
+  border: none;
+  border-radius: $progress-border-radius;
+  color: $progress-status-color;
+  display: block;
+  height: $progress-height;
+  width: $progress-width;
 
-@-o-keyframes progress {
-  0% {
-    background-position: 0px 0px;
+  &::-webkit-progress-bar {
+    background-color: $progress-background-color;
+    border-radius: $progress-border-radius;
   }
-  100% {
-    background-position: 40px 0px;
-  }
-}
 
-@keyframes progress {
-  0% {
-    background-position: 0px 0px;
+  &::-webkit-progress-value {
+    @include animated-progress;
+    background-color: $progress-status-color;
+    border-radius: $progress-border-radius;
   }
-  100% {
-    background-position: 40px 0px;
+
+  &::-moz-progress-bar {
+    @include animated-progress;
+    background-color: $progress-status-color;
+    border-radius: $progress-border-radius;
+  }
+
+  &::-ms-fill {
+    @include animated-progress;
+    background-color: $progress-status-color;
+    border: none;
   }
 }


### PR DESCRIPTION
Here's an updated progress bar refill using the html5 progress element! I kept the same progress bar styles for the most part with a few design tweaks. This still needs some full cross browser testing (for example, the animation isn't working in Firefox) before it's ready to incorporate, but I'd love some initial feedback.

![progress-bars](https://cloud.githubusercontent.com/assets/919800/6196732/6a5b0632-b3a9-11e4-93a0-874cb2cdb4fb.gif)

