### PR TITLE
Refine tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Gem Version](http://img.shields.io/gem/v/refills.svg?style=flat)](https://rubygems.org/gems/refills)
 [![Build Status](https://travis-ci.org/thoughtbot/refills.svg?branch=master)](https://travis-ci.org/thoughtbot/refills)
 
-## Prepackaged patterns and components built with Bourbon and Neat
+## Components and patterns built with Bourbon and Neat
 
 - **[Examples & Code Snippets](http://refills.bourbon.io)**
 - **[Changelog](https://github.com/thoughtbot/refills/releases)**
@@ -76,7 +76,7 @@ body {
 - [Bourbon](https://github.com/thoughtbot/bourbon): A simple and lightweight mixin library for Sass
 - [Neat](https://github.com/thoughtbot/neat): A lightweight semantic grid framework for Sass and Bourbon
 - [Bitters](https://github.com/thoughtbot/bitters): Scaffold styles, variables and structure for Bourbon projects
-- [Refills](https://github.com/thoughtbot/refills): Prepackaged patterns and components built with Bourbon, Neat and Bitters
+- [Refills](https://github.com/thoughtbot/refills): Components and patterns built with Bourbon and Neat
 
 ## Credits
 

--- a/refills.gemspec
+++ b/refills.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |s|
   s.version       = Refills::VERSION
   s.authors       = ['Christian Reuter', 'Joël Quenneville', 'Lisa Sy', 'Magnus Gyllensward', 'Paul Smith', 'Tyson Gach']
   s.email         = 'design+bourbon@thoughtbot.com'
-  s.description   = 'Prepackaged patterns and components built with Bourbon, Neat and Bitters.'
-  s.summary       = 'Prepackaged patterns and components built with Bourbon, Neat and Bitters.'
+  s.description   = 'Components and patterns built with Bourbon and Neat.'
+  s.summary       = 'Components and patterns built with Bourbon and Neat.'
   s.homepage      = 'http://refills.bourbon.io'
   s.license       = 'MIT'
 

--- a/sache.json
+++ b/sache.json
@@ -1,5 +1,5 @@
 {
   "name": "Refills",
-  "description": "Prepackaged patterns and components built with Bourbon, Neat and Bitters.",
+  "description": "Components and patterns built with Bourbon and Neat.",
   "tags": ["gui", "buttons", "patterns", "components", "templates", "navigation", "tabs", "framework", "elements", "neat", "bourbon", "bitters"]
 }

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <meta name="description" content="Refills are prepackaged patterns and components built with Bourbon, Neat and Bitters.">
+    <meta name="description" content="Components and patterns built with Bourbon and Neat.">
     <title>Refills<%= " - #{ current_page.data.title}" if current_page.data.title %></title>
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Oswald:400,300,700|Lusitana:400,700|Open+Sans:400,800">
     <%= stylesheet_link_tag "all" %>
@@ -44,7 +44,7 @@
         </footer>
       </section>
     </section>
-    
+
     <script src="https://maps.googleapis.com/maps/api/js"></script>
     <script>
       var bittersMap = (function () {

--- a/source/refills-hero.html.erb
+++ b/source/refills-hero.html.erb
@@ -2,6 +2,6 @@
   <div class="refills-logo">
     <img src="/images/refills-logo.svg" alt="Refills logo">
   </div>
-  <h2><span>Refills</span> are prepackaged patterns and components, built on top of <a href="http://www.bourbon.io">Bourbon</a> and <a href="http://neat.bourbon.io/">Neat</a>.</h2>
-  <p>Managed by <a href="http://www.thoughtbot.com">thoughtbot</a>, instructions at <a href="https://github.com/thoughtbot/refills">GitHub</a></p>
+  <h2>Components and patterns built with <a href="//bourbon.io">Bourbon</a> and <a href="//neat.bourbon.io">Neat</a>.</h2>
+  <p>Managed by <a href="http://thoughtbot.com">thoughtbot</a>, instructions at <a href="//github.com/thoughtbot/refills">GitHub</a></p>
 </div>


### PR DESCRIPTION
I’d like to refine the tagline for Refills to:

> “Components and patterns built with Bourbon and Neat”

- It’s clear and concise
- The “built on top of” wording in the existing tagline feels odd
- To me, patterns _expand upon_ components (components are self-contained, but components help create larger patterns); so I put components first in the wording
- The current tagline is slightly different in many places, e.g. [thoughtbot.com](http://thoughtbot.com/open-source) and the [Refills GitHub](https://github.com/thoughtbot/refills/blob/master/README.md)
- This also continues to remove “Bitters” from the tagline, which is no longer a dependency but is lingering around in a few instances (I’ll put a PR up for thoughtbot.com, as well, if this gets a thumbs up)