### PR TITLE
Dropdowns should only toggle one at a time

### DIFF
--- a/source/javascripts/refills/coffeescript/dropdown.coffee
+++ b/source/javascripts/refills/coffeescript/dropdown.coffee
@@ -1,11 +1,11 @@
 $(document).ready ->
-  $('.dropdown-button').click ->
-    $('.dropdown-menu').toggleClass 'show-menu'
-    $('.dropdown-menu > li').click ->
-      $('.dropdown-menu').removeClass 'show-menu'
-      return
-    $('.dropdown-menu.dropdown-select > li').click ->
-      $('.dropdown-button').html $(this).html()
+  $(".dropdown-button").click ->
+    $button = $(this)
+    $menu = $button.siblings(".dropdown-menu")
+    $menu.toggleClass "show-menu"
+    $menu.children("li").click ->
+      $menu.removeClass "show-menu"
+      $button.html $(this).html()
       return
     return
   return

--- a/source/javascripts/refills/dropdown.js
+++ b/source/javascripts/refills/dropdown.js
@@ -1,12 +1,12 @@
-$(document).ready(function(){
+$(document).ready(function() {
   $(".dropdown-button").click(function() {
-    $(".dropdown-menu").toggleClass("show-menu");
-    $(".dropdown-menu > li").click(function(){
-      $(".dropdown-menu").removeClass("show-menu");
-    });
-    $(".dropdown-menu.dropdown-select > li").click(function() {
-      $(".dropdown-button").html($(this).html());
+    var $button, $menu;
+    $button = $(this);
+    $menu = $button.siblings(".dropdown-menu");
+    $menu.toggleClass("show-menu");
+    $menu.children("li").click(function() {
+      $menu.removeClass("show-menu");
+      $button.html($(this).html());
     });
   });
 });
-


### PR DESCRIPTION
This fix will prevent all dropdowns from opening at the same time in the event that more than one is put on a page by binding the toggle to the element that is clicked not a page-wide jquery selector.

A few things worth note:

This PR includes manually converted JS -> Coffeescript via js2.coffee as the automatic converter (`rake coffee`) reverted my changes, but left the js unchanged?

The contribution docs make no note of having to install the npm package `js2coffee`, which was easy enough to figure out but should probably be included via a `package.json`.

Finally when running `rake coffee` several files were changed unrelated to anything I've done (`source/javascripts/refills/coffeescript/accordion_tabs.coffee`, `source/javascripts/refills/coffeescript/accordion_tabs_minimal.coffee`, `source/javascripts/refills/coffeescript/navigation_centered.coffee`).