### PR TITLE
Fix for missing tab-link class causing broken links in accordion content

### DIFF
--- a/source/javascripts/refills/coffeescript/accordion_tabs.coffee
+++ b/source/javascripts/refills/coffeescript/accordion_tabs.coffee
@@ -2,7 +2,7 @@ $(document).ready ->
   $('.accordion-tabs').each ->
     $(this).children('li').first().children('a').addClass('is-active').next().addClass('is-open').show()
     return
-  $('.accordion-tabs').on 'click', 'li > a', (event) ->
+  $('.accordion-tabs').on 'click', 'li > a.tab-link', (event) ->
     if !$(this).hasClass('is-active')
       event.preventDefault()
       accordionTabs = $(this).closest('.accordion-tabs')

--- a/source/javascripts/refills/coffeescript/accordion_tabs_minimal.coffee
+++ b/source/javascripts/refills/coffeescript/accordion_tabs_minimal.coffee
@@ -2,7 +2,7 @@ $(document).ready ->
   $('.accordion-tabs-minimal').each (index) ->
     $(this).children('li').first().children('a').addClass('is-active').next().addClass('is-open').show()
     return
-  $('.accordion-tabs-minimal').on 'click', 'li > a', (event) ->
+  $('.accordion-tabs-minimal').on 'click', 'li > a.tab-link', (event) ->
     if !$(this).hasClass('is-active')
       event.preventDefault()
       accordionTabs = $(this).closest('.accordion-tabs-minimal')


### PR DESCRIPTION
I noticed that a class specifier (.tab-link) is missing in the link selector, but only in the Coffeescript files for the accordion class. This causes links in the accordion-content to break.