### PR TITLE
Fix `.more` dissapearing on chrome >= 45

### DIFF
--- a/source/stylesheets/refills/_navigation.scss
+++ b/source/stylesheets/refills/_navigation.scss
@@ -96,6 +96,7 @@ header.navigation {
       display: inline;
       margin: 0;
       padding: 0;
+      position: relative;
     }
   }
 


### PR DESCRIPTION
At the time of writing chrome>=45 broke navigation positioning when
using the `.more` class making the parent container position relative
fixes this issue.

Unfortunately submenu's don't work either in chrome>=45 but I don't have
enough time to look at it right now.

fixes #332