### PR TITLE
Recommend installing in the development group

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Alternative to copy-pasting manually, we also have a Refills gem that allows you
 1. Add Refills to your Gemfile:
 
   ```ruby
-  gem 'refills'
+  gem "refills", group: :development
   ```
 
 2. Then run:


### PR DESCRIPTION
Refills is not needed at runtime. The gem is used as a generator when
developing. Loading it in production contributes to memory use, which
can become a problem multiplied across several processes in low-memory
environments such as Heroku.