### PR TITLE
Remove deprecated Bourbon features

### DIFF
--- a/source/_search_bar.html.erb
+++ b/source/_search_bar.html.erb
@@ -1,6 +1,6 @@
 <form class="search-bar" role="search">
   <input type="search" placeholder="Enter Search" />
   <button type="submit">
-    <img src="https://raw.githubusercontent.com/thoughtbot/refills/master/source/images/search-icon.png" alt="Search Icon">
+    <img src="https://raw.githubusercontent.com/thoughtbot/refills/master/source/images/search-icon-black.png" alt="Search Icon">
   </button>
 </form>

--- a/source/stylesheets/refills/_search-bar.scss
+++ b/source/stylesheets/refills/_search-bar.scss
@@ -1,10 +1,8 @@
 form.search-bar {  
   ///////////////////////////////////////////////////////////////////////////////////
+  $base-spacing: 1.5em !default;
   $base-border-color: gainsboro !default;
-  $base-border-radius: 3px !default;
   $base-line-height: 1.5em !default;
-  $action-color: #477DCA !default;
-  $dark-gray: #333 !default;
   //////////////////////////////////////////////////////////////////////////////////
 
   $search-bar-border-color: $base-border-color;
@@ -15,12 +13,10 @@ form.search-bar {
 
   input[type=search] {
     @include appearance(none);
-    @include box-sizing(border-box);
     @include transition(border-color);
     background-color: white;
-    border-radius: $base-border-radius;
-    border-radius: $base-border-radius;
     border: 1px solid $base-border-color;
+    box-sizing: border-box;
     display: block;
     font-size: 1em;
     font-style: italic;
@@ -31,10 +27,7 @@ form.search-bar {
   }
 
   button[type=submit] {
-    @include button(flat, $action-color);
     @include position(absolute, 0em 0em 0em null);
-    border-bottom-left-radius: 0;
-    border-top-left-radius: 0;
     outline: none;
     padding: 5px 10px;
 


### PR DESCRIPTION
Remove `button` mixin and `box-sizing` due to deprecation.

![image](https://cloud.githubusercontent.com/assets/2095625/10997432/6103d07c-848d-11e5-8390-b19edfca5d43.png)

