### PR TITLE
Fix the build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,14 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'middleman'
-
-gem 'bourbon', '~> 4.1.0'
-gem 'middleman-gh-pages'
-gem 'middleman-livereload', '~> 3.1.0'
-gem 'neat', '~> 1.7.0'
-gem 'sass', '~> 3.4.0'
+gem "middleman", "~> 3.4"
+gem "bourbon", "~> 4.2"
+gem "middleman-gh-pages", "~> 0.3"
+gem "middleman-livereload", "~> 3.4"
+gem "neat", "~> 1.7"
+gem "sass", "~> 3.4"
 
 group :test do
-  gem 'rspec'
+  gem "rspec"
   gem "generator_spec", github: "stevehodgkiss/generator_spec", tag: "0.9.3"
-  gem 'railties'
+  gem "railties"
 end

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 [![Refills](http://images.thoughtbot.com/bourbon/refills-logo.svg)](http://refills.bourbon.io)
 
-[![Gem Version](http://img.shields.io/gem/v/refills.svg?style=flat)](https://rubygems.org/gems/refills)
-[![Build Status](https://travis-ci.org/thoughtbot/refills.svg?branch=master)](https://travis-ci.org/thoughtbot/refills)
-
 ## Components and patterns built with Bourbon and Neat
 
 - **[Examples & Code Snippets](http://refills.bourbon.io)**

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,7 @@
+general:
+  branches:
+    ignore:
+      - gh-pages
+test:
+  override:
+    - bundle exec rake


### PR DESCRIPTION
The build was failing because we didn’t lock down Middleman to v3.x, and it was installing v4.x, which is a major upgrade and removes Sprockets, which we need.

- Add CircleCI configuration (I removed the Travis integration and replaced it with Circle, as we do on most of our projects)
- Update and lock down gems