### PR TITLE
syntax update and copyright year change

### DIFF
--- a/index.html
+++ b/index.html
@@ -1665,7 +1665,7 @@
   } 
 
   .footer-links {
-    @include display(flex);
+    @include display-flex(flex);
     @include justify-content(center);
     @include flex-wrap(wrap);
     margin-bottom: $base-spacing;
@@ -4788,7 +4788,7 @@ $('.js-vertical-tab-accordion-heading').click (event) -&gt;
             <img src="/images/ralph-gray.png" alt="thoughtbot Ralph logo mark">
           </div>
           <p>Refills is maintained and funded by <a href="//thoughtbot.com">thoughtbot, inc</a>.</p>
-          <p>Copyright &copy; 2014&ndash;2015 <a href="//thoughtbot.com">thoughtbot, inc</a>. Refills is free software, and may be redistributed under the terms specified in the <a href="//github.com/thoughtbot/refills/blob/master/LICENSE.md">license</a>.</p>
+          <p> Copyright &copy; 2014<script>new Date().getFullYear()>2014&&document.write("-"+new Date().getFullYear());</script>, <a href="//thoughtbot.com">thoughtbot, inc</a>. Refills is free software, and may be redistributed under the terms specified in the <a href="//github.com/thoughtbot/refills/blob/master/LICENSE.md">license</a>.</p>
         </footer>
       </section>
     </section>


### PR DESCRIPTION
In the latest version of Compass, display(flex) has been changed to display-flex(flex) so updated in the footer sections - display(flex) is also used in a few other refills on this page but haven't personally used or tested them, might be broken there too. Also updated copyright year with javascript to keep it accurate in any year.