### PR TITLE
Fix JS error that happens when more menu is not used in nav

### DIFF
--- a/source/javascripts/refills/centered_navigation.js
+++ b/source/javascripts/refills/centered_navigation.js
@@ -1,18 +1,20 @@
 $(window).on("load resize",function(e) {
-
   var more = document.getElementById("js-centered-more");
-  var windowWidth = $(window).width();
-  var moreLeftSideToPageLeftSide = $(more).offset().left;
-  var moreLeftSideToPageRightSide = windowWidth - moreLeftSideToPageLeftSide;
 
-  if (moreLeftSideToPageRightSide < 330) {
-    $("#js-centered-more .submenu .submenu").removeClass("fly-out-right");
-    $("#js-centered-more .submenu .submenu").addClass("fly-out-left");
-  }
+  if ($(more).length > 0) {
+    var windowWidth = $(window).width();
+    var moreLeftSideToPageLeftSide = $(more).offset().left;
+    var moreLeftSideToPageRightSide = windowWidth - moreLeftSideToPageLeftSide;
 
-  if (moreLeftSideToPageRightSide > 330) {
-    $("#js-centered-more .submenu .submenu").removeClass("fly-out-left");
-    $("#js-centered-more .submenu .submenu").addClass("fly-out-right");
+    if (moreLeftSideToPageRightSide < 330) {
+      $("#js-centered-more .submenu .submenu").removeClass("fly-out-right");
+      $("#js-centered-more .submenu .submenu").addClass("fly-out-left");
+    }
+
+    if (moreLeftSideToPageRightSide > 330) {
+      $("#js-centered-more .submenu .submenu").removeClass("fly-out-left");
+      $("#js-centered-more .submenu .submenu").addClass("fly-out-right");
+    }
   }
 
   var menuToggle = $("#js-centered-navigation-mobile-menu").unbind();

--- a/source/javascripts/refills/navigation.js
+++ b/source/javascripts/refills/navigation.js
@@ -1,17 +1,19 @@
 $(window).resize(function() {
   var more = document.getElementById("js-navigation-more");
-  var windowWidth = $(window).width();
-  var moreLeftSideToPageLeftSide = $(more).offset().left;
-  var moreLeftSideToPageRightSide = windowWidth - moreLeftSideToPageLeftSide;
+  if ($(more).length > 0) {
+    var windowWidth = $(window).width();
+    var moreLeftSideToPageLeftSide = $(more).offset().left;
+    var moreLeftSideToPageRightSide = windowWidth - moreLeftSideToPageLeftSide;
 
-  if (moreLeftSideToPageRightSide < 330) {
-    $("#js-navigation-more .submenu .submenu").removeClass("fly-out-right");
-    $("#js-navigation-more .submenu .submenu").addClass("fly-out-left");
-  }
+    if (moreLeftSideToPageRightSide < 330) {
+      $("#js-navigation-more .submenu .submenu").removeClass("fly-out-right");
+      $("#js-navigation-more .submenu .submenu").addClass("fly-out-left");
+    }
 
-  if (moreLeftSideToPageRightSide > 330) {
-    $("#js-navigation-more .submenu .submenu").removeClass("fly-out-left");
-    $("#js-navigation-more .submenu .submenu").addClass("fly-out-right");
+    if (moreLeftSideToPageRightSide > 330) {
+      $("#js-navigation-more .submenu .submenu").removeClass("fly-out-left");
+      $("#js-navigation-more .submenu .submenu").addClass("fly-out-right");
+    }
   }
 });
 


### PR DESCRIPTION
This simply uses an if-statement to check that `more` exists in the nav before taking it for granted in calculations. Thus preventing errors.