### PR TITLE
Add missing border-right: 0 to _tables.scss

### DIFF
--- a/source/stylesheets/refills/_tables.scss
+++ b/source/stylesheets/refills/_tables.scss
@@ -21,8 +21,8 @@
   border: $table-border;
   border-collapse: separate;
   border-left: 0;
-  border-right: 0;
   border-radius: $base-border-radius;
+  border-right: 0;
   border-spacing: 0;
   width: 100%;
 

--- a/source/stylesheets/refills/_tables.scss
+++ b/source/stylesheets/refills/_tables.scss
@@ -21,6 +21,7 @@
   border: $table-border;
   border-collapse: separate;
   border-left: 0;
+  border-right: 0;
   border-radius: $base-border-radius;
   border-spacing: 0;
   width: 100%;


### PR DESCRIPTION
Refils tables (regular tables rather than the minimal tables) has a styling error in that the right border is shown whilst the left border is hidden.

This PR adds the missing single line of CSS to the repo