### PR TITLE
Support children in dropdown toggles

### DIFF
--- a/source/javascripts/refills/dropdown.js
+++ b/source/javascripts/refills/dropdown.js
@@ -8,7 +8,7 @@ $(function() {
   }
 
   $(toggleSelector).on('click', function(event) {
-    var button = $(event.target);
+    var button = findButton(event.target);
     var dropdown = $('#' + button.attr('aria-controls'));
     var isExpanded = dropdown.attr('aria-hidden') === 'false';
 
@@ -20,14 +20,10 @@ $(function() {
     }
   });
 
-  function parentIsMenu(element) {
-    return $(element).parents(menuSelector).length > 0;
-  }
-
   $('body').click(function(event) {
-    var target = $(event.target);
+    var button = findButton(event.target);
 
-    if (!(target.is(toggleSelector) || parentIsMenu(event.target))) {
+    if (!(button.is(toggleSelector) || parentIsMenu(event.target))) {
       closeDropdowns();
     }
   });
@@ -39,4 +35,16 @@ $(function() {
       closeDropdowns();
     }
   });
+
+  function findButton(element) {
+    if ($(element).is(toggleSelector)) {
+      return $(element);
+    } else {
+      return $(element).closest(toggleSelector);
+    }
+  }
+
+  function parentIsMenu(element) {
+    return $(element).parents(menuSelector).length > 0;
+  }
 });

--- a/source/stylesheets/refills/_dropdown.scss
+++ b/source/stylesheets/refills/_dropdown.scss
@@ -8,6 +8,7 @@
   border: $base-border;
   margin-top: $small-spacing;
   min-width: 12em;
+  z-index: 1;
 
   &[aria-hidden="true"] {
     display: none;


### PR DESCRIPTION
When clicking a child in a dropdown toggle, we were referring to that
child as the target, rather than referring to the button itself.

This change checks to see if the target is the toggle, and looks for a
parent toggle if it isn't.

Fixes https://github.com/thoughtbot/refills/issues/438

![dropdown](https://cloud.githubusercontent.com/assets/2317604/26254115/79448a14-3c83-11e7-99da-aa765e56178c.gif)
